### PR TITLE
Unnamed struct support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ MIDA is a single-header library that attaches size and length metadata to C nati
 - **Size and length tracking** for arrays without manual bookkeeping
 - **Familiar API** through wrappers for `malloc`, `calloc`, `realloc`, and `free`
 - **Compound literal support** for creating arrays with metadata attached
+- **Nested structure support** for complex data structures
 - **No dependencies** beyond standard C libraries
 - **Header-only** implementation for easy integration
 - **Zero overhead** for accessing array elements
@@ -20,9 +21,9 @@ MIDA is a single-header library that attaches size and length metadata to C nati
 ### Creating Arrays with Compound Literals
 
 ```c
-// Create arrays with compound literals
-int *numbers = mida_compound_literal(int, 1, 2, 3, 4, 5);
-char *letters = mida_compound_literal(char, 'a', 'b', 'c', 'd');
+// Create arrays with compound literals (using C99 designated initializers)
+int *numbers = mida_unnamed_array(int, { 1, 2, 3, 4, 5 });
+char *letters = mida_unnamed_array(char, { 'a', 'b', 'c', 'd' });
 
 // Access the metadata
 size_t len = mida_length(numbers);  // 5
@@ -32,6 +33,54 @@ size_t size = mida_sizeof(numbers); // 20 bytes (5 * sizeof(int))
 for (size_t i = 0; i < mida_length(numbers); i++) {
     printf("%d ", numbers[i]);  // Outputs: 1 2 3 4 5
 }
+```
+
+### Creating Nested Structures
+
+```c
+// Define a structure with nested arrays
+struct my_data {
+    int *numbers;
+    float *values;
+};
+
+// Create a structure with metadata
+struct my_data *data = mida_unnamed_struct(
+    struct my_data, {
+        .numbers = mida_unnamed_array(int, { 1, 2, 3 }),
+        .values = mida_unnamed_array(float, { 1.0f, 2.0f, 3.0f })
+    }
+);
+
+// Access data and metadata
+printf("Number of elements: %zu\n", mida_length(data->numbers)); // 3
+printf("First value: %f\n", data->values[0]); // 1.0
+```
+
+### Deep Nesting
+
+```c
+// Create deeply nested arrays (like a 2D string array)
+char ***nested = mida_unnamed_array(
+    char **, {
+        mida_unnamed_array(char *, { 
+            mida_unnamed_array(char, { 'f', 'o', 'o', '\0' }),
+            mida_unnamed_array(char, { 'b', 'a', 'r', '\0' })
+        }),
+        mida_unnamed_array(char *, {
+            mida_unnamed_array(char, { 'h', 'i', '\0' })
+        })
+    }
+);
+
+// Access elements from deep nesting
+printf("%s %s\n", nested[0][0], nested[0][1]); // "foo bar"
+printf("%s\n", nested[1][0]); // "hi"
+
+// Access metadata at any level
+printf("Outer length: %zu\n", mida_length(nested)); // 2
+printf("Inner length: %zu\n", mida_length(nested[0])); // 2
+printf("String length: %zu\n", mida_length(nested[0][0])); // 4 (including \0)
 ```
 
 ### Using Memory Management Functions
@@ -70,6 +119,34 @@ Memory Layout:
                 ^
                 |
          Pointer returned to user
+```
+
+## Mixing with Regular C Arrays
+
+You can also use MIDA to wrap only the outermost container while using regular C arrays inside:
+
+```c
+// Regular C arrays
+int matrix[][2] = { {1, 2}, {3, 4} };
+const char *names[] = {"Alice", "Bob"};
+
+// Wrap in a MIDA container
+void **container = mida_unnamed_array(
+    void *, {
+        (void*)matrix,
+        (void*)names
+    }
+);
+
+// Only the container has metadata
+printf("Container size: %zu\n", mida_length(container)); // 2
+
+// Access inner arrays normally (casting back to appropriate type)
+int (*m)[2] = (int(*)[2])container[0];
+printf("Matrix value: %d\n", m[1][0]); // 3
+
+const char **n = (const char**)container[1];
+printf("Name: %s\n", n[1]); // "Bob"
 ```
 
 ## Build


### PR DESCRIPTION
This pull request introduces several significant updates to the MIDA library, focusing on enhanced support for nested structures, improved API usability, and expanded test coverage. The most important changes include the addition of nested structure and deep nesting support, a refactor of the API to use `mida_unnamed_array` and `mida_unnamed_struct`, and new test cases for these features.

### Enhancements to library features:
* Added support for nested structures and deep nesting, allowing users to create and manage complex data structures (e.g., 2D arrays or arrays of structures) with metadata tracking. (`README.md`: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R85) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124-R151); `mida.h`: [[3]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL33-R59)
* Introduced `mida_unnamed_array` and `mida_unnamed_struct` macros to replace `mida_compound_literal`, providing a more consistent and flexible API for creating arrays and structures with metadata. (`mida.h`: [mida.hL33-R59](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL33-R59))

### Documentation updates:
* Updated the `README.md` to reflect the new features, including examples of using `mida_unnamed_array` and `mida_unnamed_struct`, as well as guidance for handling nested and mixed structures. (`README.md`: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R85) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124-R151)

### Codebase improvements:
* Refactored internal functions and macros, such as renaming `mida_wrap` to `__mida_unnamed_wrap`, to align with the new API naming conventions. (`mida.h`: [[1]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL33-R59) [[2]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL105-R109)
* Added type casting for improved type safety in functions like `mida_realloc` and `mida_free`. (`mida.h`: [[1]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL89-R89) [[2]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL105-R109)

### Test suite expansion:
* Added new test cases to validate the functionality of nested structures, deep nesting, and mixed regular/mida-managed arrays. These tests ensure correctness and demonstrate the new features. (`test/test.c`: [[1]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L5-R41) [[2]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L154-R264)
* Updated existing test cases to use the new `mida_unnamed_array` API. (`test/test.c`: [[1]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L5-R41) [[2]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L42-R56)

### Minor fixes:
* Removed redundant `stdlib.h` include from `mida.h` and re-added it where necessary to minimize unnecessary dependencies. (`mida.h`: [[1]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL9) [[2]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL33-R59)