### PR TITLE
Feat/first version

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ data = mida_realloc(data, sizeof(float), 20);
 mida_free(data);
 ```
 
+## C89 Compatibility Mode (without Compound Literals)
+
+MIDA provides an alternative API for C89 compatibility:
+
+```c
+// Create a bytemap buffer to hold data and metadata
+int data[] = {1, 2, 3, 4, 5};
+MIDA_BYTEMAP(bytemap, sizeof(data));
+
+// Wrap existing data with metadata
+int *wrapped = mida_wrap(data, bytemap);
+
+// Access metadata as usual
+printf("Length: %zu\n", mida_length(wrapped)); // 5
+```
+
 ## Memory Management
 
 MIDA uses a clever approach to store metadata alongside the array data. Each mida-managed array is prefixed with a small header containing:
@@ -149,16 +165,50 @@ const char **n = (const char**)container[1];
 printf("Name: %s\n", n[1]); // "Bob"
 ```
 
+## API Reference
+
+### Core Functions
+
+| Function | Description |
+|----------|-------------|
+| `void *mida_malloc(size_t element_size, size_t count)` | Allocates memory with metadata for `count` elements of size `element_size` |
+| `void *mida_calloc(size_t element_size, size_t count)` | Allocates zeroed memory with metadata for `count` elements of size `element_size` |
+| `void *mida_realloc(void *ptr, size_t element_size, size_t count)` | Resizes memory with metadata for `count` elements of size `element_size` |
+| `void mida_free(void *ptr)` | Frees memory allocated with MIDA functions |
+
+### C99 Macros (Compound Literals)
+
+| Macro | Description |
+|-------|-------------|
+| `mida_array(type, {...})` | Creates an array with metadata using compound literals |
+| `mida_struct(type, {...})` | Creates a structure with metadata using compound literals |
+| `mida_bytemap(size)` | Creates a bytemap buffer with the specified size (for internal use) |
+
+### C89 Compatibility Macros
+
+| Macro | Description |
+|-------|-------------|
+| `MIDA_BYTEMAP(bytemap, size)` | Defines a bytemap buffer to hold metadata and data |
+| `mida_wrap(data, bytemap)` | Wraps existing data with metadata using a bytemap buffer |
+
+### Metadata Access Macros
+
+| Macro | Description |
+|-------|-------------|
+| `mida_sizeof(ptr)` | Gets the total size in bytes of data managed by MIDA |
+| `mida_length(ptr)` | Gets the number of elements in an array managed by MIDA |
+| `mida_container(ptr)` | Gets the container structure for a given data pointer |
+
 ## Build
 
-mida is single-header-only library, so it includes additional macros for more complex uses cases. `#define MIDA_STATIC` hides all mida API symbols by making them static. Also, if you want to include `mida.h` from multiple C files, to avoid duplication of symbols you may define `MIDA_HEADER` macro.
+MIDA is single-header-only library, so it includes additional macros for more complex uses cases. `#define MIDA_STATIC` hides all mida API symbols by making them static. Also, if you want to include `mida.h` from multiple C files, to avoid duplication of symbols you may define `MIDA_HEADER` macro.
 
 ```c
-/* In every .c file that uses mida include only declarations: */
+/* In every .c file that uses MIDA include only declarations: */
 #define MIDA_HEADER
 #include "mida.h"
 
-/* Additionally, create one mida.c file for mida implementation: */
+/* Additionally, create one mida.c file for MIDA implementation: */
 #include "mida.h"
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ MIDA is a single-header library that attaches size and length metadata to C nati
 
 ```c
 // Create arrays with compound literals (using C99 designated initializers)
-int *numbers = mida_unnamed_array(int, { 1, 2, 3, 4, 5 });
-char *letters = mida_unnamed_array(char, { 'a', 'b', 'c', 'd' });
+int *numbers = mida_array(int, { 1, 2, 3, 4, 5 });
+char *letters = mida_array(char, { 'a', 'b', 'c', 'd' });
 
 // Access the metadata
 size_t len = mida_length(numbers);  // 5
@@ -45,10 +45,10 @@ struct my_data {
 };
 
 // Create a structure with metadata
-struct my_data *data = mida_unnamed_struct(
+struct my_data *data = mida_struct(
     struct my_data, {
-        .numbers = mida_unnamed_array(int, { 1, 2, 3 }),
-        .values = mida_unnamed_array(float, { 1.0f, 2.0f, 3.0f })
+        .numbers = mida_array(int, { 1, 2, 3 }),
+        .values = mida_array(float, { 1.0f, 2.0f, 3.0f })
     }
 );
 
@@ -61,14 +61,14 @@ printf("First value: %f\n", data->values[0]); // 1.0
 
 ```c
 // Create deeply nested arrays (like a 2D string array)
-char ***nested = mida_unnamed_array(
+char ***nested = mida_array(
     char **, {
-        mida_unnamed_array(char *, { 
-            mida_unnamed_array(char, { 'f', 'o', 'o', '\0' }),
-            mida_unnamed_array(char, { 'b', 'a', 'r', '\0' })
+        mida_array(char *, { 
+            mida_array(char, { 'f', 'o', 'o', '\0' }),
+            mida_array(char, { 'b', 'a', 'r', '\0' })
         }),
-        mida_unnamed_array(char *, {
-            mida_unnamed_array(char, { 'h', 'i', '\0' })
+        mida_array(char *, {
+            mida_array(char, { 'h', 'i', '\0' })
         })
     }
 );
@@ -131,7 +131,7 @@ int matrix[][2] = { {1, 2}, {3, 4} };
 const char *names[] = {"Alice", "Bob"};
 
 // Wrap in a MIDA container
-void **container = mida_unnamed_array(
+void **container = mida_array(
     void *, {
         (void*)matrix,
         (void*)names

--- a/mida.h
+++ b/mida.h
@@ -17,32 +17,125 @@ extern "C" {
 #define MIDA_API extern
 #endif /* MIDA_STATIC */
 
+/**
+ * @typedef mida_byte
+ * @brief Type used for raw byte operations
+ *
+ * Alias for char used for buffer operations to make it clearer that
+ * we're dealing with raw bytes rather than characters.
+ */
 typedef char mida_byte;
 
+/**
+ * @def MIDA_BYTEMAP(_bytemap, _size)
+ * @brief Defines a bytemap for storing metadata
+ *
+ * Creates a bytemap buffer of the appropriate size to hold both the
+ * metadata structure and the user data.
+ *
+ * @param _bytemap Name of the bytemap array
+ * @param _size Size of the data that will be stored with metadata
+ */
 #define MIDA_BYTEMAP(_bytemap, _size)                                         \
     mida_byte(_bytemap)[sizeof(struct mida) + (_size)]
 
-// alloc (sizeof(struct mida) - 1) + sizeof(_type[])
-// the -1 is to account for mida->data[0] which is not part of the size
+/**
+ * @struct mida
+ * @brief Structure that holds metadata about an array
+ *
+ * This structure is prefixed to all data managed by MIDA. It stores
+ * information about the total size and number of elements in the array.
+ * The data field is a flexible array member that marks the start of
+ * the actual array data.
+ *
+ * @note The size calculation for allocation is (sizeof(struct mida) - 1) +
+ * sizeof(_type[]), where the -1 accounts for mida->data[0] which is part
+ * of the struct but not counted in the size.
+ */
 struct mida {
+    /** Total size of the data in bytes */
     size_t size;
+    /** Number of elements in the array */
     size_t length;
+    /** Start of the actual array data (flexible array member) */
     mida_byte data[1];
 };
 
+/**
+ * @brief Allocates memory with MIDA metadata
+ *
+ * Works like standard malloc but stores metadata about the allocated
+ * array, allowing size and length information to be retrieved later.
+ *
+ * @param element_size Size of each element in bytes
+ * @param count Number of elements to allocate
+ * @return Pointer to the allocated memory, or NULL if allocation fails
+ */
 MIDA_API void *mida_malloc(size_t element_size, size_t count);
 
+/**
+ * @brief Allocates zeroed memory with MIDA metadata
+ *
+ * Works like standard calloc but stores metadata about the allocated
+ * array, allowing size and length information to be retrieved later.
+ *
+ * @param element_size Size of each element in bytes
+ * @param count Number of elements to allocate
+ * @return Pointer to the allocated memory, or NULL if allocation fails
+ */
 MIDA_API void *mida_calloc(size_t element_size, size_t count);
 
+/**
+ * @brief Resizes memory with MIDA metadata
+ *
+ * Works like standard realloc but preserves metadata about the array,
+ * updating it to reflect the new size and length.
+ *
+ * @param ptr Pointer to memory previously allocated with MIDA functions, or
+ * NULL
+ * @param element_size Size of each element in bytes
+ * @param count Number of elements in the resized array
+ * @return Pointer to the resized memory, or NULL if reallocation fails
+ */
 MIDA_API void *mida_realloc(void *ptr, size_t element_size, size_t count);
 
+/**
+ * @brief Frees memory allocated with MIDA functions
+ *
+ * Works like standard free but accounts for the metadata structure.
+ *
+ * @param ptr Pointer to memory previously allocated with MIDA functions
+ */
 MIDA_API void mida_free(void *ptr);
 
+/**
+ * @brief Internal function to wrap existing data with MIDA metadata
+ *
+ * This function copies data into a bytemap buffer and initializes the
+ * metadata structure at the beginning of the buffer.
+ *
+ * @param data Pointer to the data to wrap
+ * @param size Total size of the data in bytes
+ * @param length Number of elements in the data
+ * @param bytemap Buffer to store the metadata and data copy
+ * @return Pointer to the data portion of the bytemap
+ */
 MIDA_API void *_mida_wrap(void *data,
                           const size_t size,
                           const size_t length,
                           mida_byte *const bytemap);
 
+/**
+ * @def mida_wrap(_data, _bytemap)
+ * @brief Wraps existing data with MIDA metadata
+ *
+ * Creates a MIDA container for existing data by copying it to a bytemap
+ * buffer and initializing the metadata.
+ *
+ * @param _data Data to wrap with metadata
+ * @param _bytemap Bytemap buffer to store the metadata and data
+ * @return Pointer to the data portion of the bytemap
+ */
 #define mida_wrap(_data, _bytemap)                                            \
     _mida_wrap(_data, sizeof(_bytemap) - sizeof(struct mida),                 \
                (sizeof(_bytemap) - sizeof(struct mida)) / sizeof *_data,      \
@@ -50,22 +143,81 @@ MIDA_API void *_mida_wrap(void *data,
 
 #ifdef MIDA_SUPPORTS_C99
 
+/**
+ * @def mida_bytemap(_size)
+ * @brief Creates a bytemap buffer with the given size
+ *
+ * C99 only. Creates a compound literal for a bytemap of the specified size.
+ *
+ * @param _size Size of the data that will be stored with metadata
+ * @return A compound literal initialized to zero
+ */
 #define mida_bytemap(_size)                                                   \
     (mida_byte[sizeof(struct mida) + _size])                                  \
     {                                                                         \
         0                                                                     \
     }
+
+/**
+ * @def mida_array(_type, ...)
+ * @brief Creates an array with MIDA metadata
+ *
+ * C99 only. Creates an array of the specified type with values provided
+ * as a compound literal, and wraps it with MIDA metadata.
+ *
+ * @param _type The type of array elements
+ * @param ... Compound literal array initialization values
+ * @return Pointer to the array with MIDA metadata
+ */
 #define mida_array(_type, ...)                                                \
     (_type *)(_mida_wrap((_type[])__VA_ARGS__, sizeof((_type[])__VA_ARGS__),  \
                          sizeof((_type[])__VA_ARGS__) / sizeof(_type),        \
                          mida_bytemap(sizeof((_type[])__VA_ARGS__))))
+
+/**
+ * @def mida_struct(_type, ...)
+ * @brief Creates a structure with MIDA metadata
+ *
+ * C99 only. Creates a structure of the specified type with values provided
+ * as a compound literal, and wraps it with MIDA metadata.
+ *
+ * @param _type The structure type
+ * @param ... Compound literal structure initialization values
+ * @return Pointer to the structure with MIDA metadata
+ */
 #define mida_struct(_type, ...) mida_array(_type, { __VA_ARGS__ })
 
 #endif /* MIDA_SUPPORTS_C99 */
 
+/**
+ * @def mida_container(_base)
+ * @brief Retrieves the MIDA container structure for a given data pointer
+ *
+ * Given a pointer to data managed by MIDA, returns a pointer to the
+ * container structure that holds its metadata.
+ *
+ * @param _base Pointer to data managed by MIDA
+ * @return Pointer to the mida structure containing the metadata
+ */
 #define mida_container(_base)                                                 \
     ((const struct mida *)((mida_byte *)(_base) - offsetof(struct mida, data)))
+
+/**
+ * @def mida_sizeof(_base)
+ * @brief Gets the total size of data managed by MIDA
+ *
+ * @param _base Pointer to data managed by MIDA
+ * @return The total size of the data in bytes
+ */
 #define mida_sizeof(_base) mida_container(_base)->size
+
+/**
+ * @def mida_length(_base)
+ * @brief Gets the number of elements in an array managed by MIDA
+ *
+ * @param _base Pointer to data managed by MIDA
+ * @return The number of elements in the array
+ */
 #define mida_length(_base) mida_container(_base)->length
 
 #ifndef MIDA_HEADER
@@ -73,6 +225,16 @@ MIDA_API void *_mida_wrap(void *data,
 #include <string.h>
 #include <stdlib.h>
 
+/**
+ * @brief Allocates memory with MIDA metadata
+ *
+ * Works like standard malloc but stores metadata about the allocated
+ * array, allowing size and length information to be retrieved later.
+ *
+ * @param element_size Size of each element in bytes
+ * @param count Number of elements to allocate
+ * @return Pointer to the allocated memory, or NULL if allocation fails
+ */
 MIDA_API void *
 mida_malloc(size_t element_size, size_t count)
 {
@@ -85,6 +247,16 @@ mida_malloc(size_t element_size, size_t count)
     return &mida->data;
 }
 
+/**
+ * @brief Allocates zeroed memory with MIDA metadata
+ *
+ * Works like standard calloc but stores metadata about the allocated
+ * array, allowing size and length information to be retrieved later.
+ *
+ * @param element_size Size of each element in bytes
+ * @param count Number of elements to allocate
+ * @return Pointer to the allocated memory, or NULL if allocation fails
+ */
 MIDA_API void *
 mida_calloc(size_t element_size, size_t count)
 {
@@ -97,6 +269,18 @@ mida_calloc(size_t element_size, size_t count)
     return &mida->data;
 }
 
+/**
+ * @brief Resizes memory with MIDA metadata
+ *
+ * Works like standard realloc but preserves metadata about the array,
+ * updating it to reflect the new size and length.
+ *
+ * @param ptr Pointer to memory previously allocated with MIDA functions, or
+ * NULL
+ * @param element_size Size of each element in bytes
+ * @param count Number of elements in the resized array
+ * @return Pointer to the resized memory, or NULL if reallocation fails
+ */
 MIDA_API void *
 mida_realloc(void *ptr, size_t element_size, size_t count)
 {
@@ -114,12 +298,31 @@ mida_realloc(void *ptr, size_t element_size, size_t count)
     return mida_malloc(element_size, count);
 }
 
+/**
+ * @brief Frees memory allocated with MIDA functions
+ *
+ * Works like standard free but accounts for the metadata structure.
+ *
+ * @param ptr Pointer to memory previously allocated with MIDA functions
+ */
 MIDA_API void
 mida_free(void *ptr)
 {
     free((void *)mida_container(ptr));
 }
 
+/**
+ * @brief Internal function to wrap existing data with MIDA metadata
+ *
+ * This function copies data into a bytemap buffer and initializes the
+ * metadata structure at the beginning of the buffer.
+ *
+ * @param data Pointer to the data to wrap
+ * @param size Total size of the data in bytes
+ * @param length Number of elements in the data
+ * @param bytemap Buffer to store the metadata and data copy
+ * @return Pointer to the data portion of the bytemap
+ */
 MIDA_API void *
 _mida_wrap(void *data,
            const size_t size,


### PR DESCRIPTION
This pull request introduces significant updates to the MIDA library, focusing on improving usability, compatibility, and documentation. The key changes include replacing the `mida_unnamed_*` macros with simplified `mida_*` macros, adding support for C89 compatibility, expanding the API documentation, and updating tests to reflect these changes.

### Macro and API Updates
* Replaced `mida_unnamed_array` and `mida_unnamed_struct` macros with `mida_array` and `mida_struct` for improved readability and simplicity. (`README.md`, `mida.h`, `test/test.c`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R51) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R71) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R150) [[5]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L14-R17) [[6]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L174-R224) [[7]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L220-R263)
* Introduced new macros for C89 compatibility (`MIDA_BYTEMAP` and `mida_wrap`) to allow metadata wrapping without compound literals. (`README.md`, `mida.h`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R104-R119) [[2]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcR10-R237)

### Documentation Enhancements
* Added detailed API reference documentation to the `README.md`, covering core functions, C99 macros, C89 compatibility macros, and metadata access macros.
* Expanded inline documentation in `mida.h` with descriptions for new and existing functions, macros, and structures. [[1]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcR10-R237) [[2]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcR250-R259) [[3]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcR272-R283) [[4]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcR301-R332)

### Test Suite Updates
* Updated existing tests to use the new `mida_array` and `mida_struct` macros. (`test/test.c`) [[1]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L14-R17) [[2]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L174-R224) [[3]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L220-R263)
* Added new tests for C89 compatibility mode to verify functionality when using `MIDA_BYTEMAP` and `mida_wrap`. (`test/test.c`) [[1]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651R36-R85) [[2]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651R300)

These updates collectively enhance the library's usability, ensure compatibility with older C standards, and improve the clarity of both the codebase and documentation.