### PR TITLE
Support custom metadata extension

### DIFF
--- a/mida.h
+++ b/mida.h
@@ -27,136 +27,348 @@ extern "C" {
 typedef char mida_byte;
 
 /**
+ * @def MIDA_EXT_BYTEMAP(_container, _bytemap, _size)
+ * @brief Defines an extended bytemap for storing metadata
+ *
+ * Creates a bytemap buffer with local storage, of the appropriate size to hold
+ * both the metadata structure and the user data.
+ *
+ * @param _container Name of the container structure
+ * @param _bytemap Name of the bytemap array
+ * @param _size Size of the data that will be stored with metadata
+ */
+#define MIDA_EXT_BYTEMAP(_container, _bytemap, _size)                         \
+    mida_byte(_bytemap)[sizeof(_container) + (_size)]
+
+/**
  * @def MIDA_BYTEMAP(_bytemap, _size)
  * @brief Defines a bytemap for storing metadata
  *
- * Creates a bytemap buffer of the appropriate size to hold both the
- * metadata structure and the user data.
+ * Creates a bytemap buffer with local storage, of the appropriate size to hold
+ * both the metadata structure and the user data.
  *
  * @param _bytemap Name of the bytemap array
  * @param _size Size of the data that will be stored with metadata
  */
 #define MIDA_BYTEMAP(_bytemap, _size)                                         \
-    mida_byte(_bytemap)[sizeof(struct mida) + (_size)]
+    MIDA_EXT_BYTEMAP(struct mida_metadata, _bytemap, _size)
 
 /**
- * @struct mida
- * @brief Structure that holds metadata about an array
+ * @def MIDA_EXT_METADATA
+ * @brief Defines the metadata structure for MIDA
+ * @note When using this macro for exxtended metadata, ensure that the
+ * macro is the last thing in the struct definition.
+ *
+ * This macro defines the metadata structure that is prefixed to all data
+ * managed by MIDA. It includes fields for size, length, and a flexible
+ * array member for the actual data.
+ */
+#define MIDA_EXT_METADATA                                                     \
+    /** Total size of the data in bytes */                                    \
+    size_t size;                                                              \
+    /** Number of elements in the array */                                    \
+    size_t length;                                                            \
+    /** Start of the actual array data (flexible array member) */             \
+    mida_byte data[1]
+
+/**
+ * @struct mida_metadata
+ * @brief Structure that holds metadata about a structure
  *
  * This structure is prefixed to all data managed by MIDA. It stores
  * information about the total size and number of elements in the array.
  * The data field is a flexible array member that marks the start of
  * the actual array data.
  *
- * @note The size calculation for allocation is (sizeof(struct mida) - 1) +
- * sizeof(_type[]), where the -1 accounts for mida->data[0] which is part
- * of the struct but not counted in the size.
+ * @note The size calculation for allocation is (sizeof(struct mida_metadata) -
+ * 1) + sizeof(_type[]), where the -1 accounts for mida_metadata->data[0] which
+ * is part of the struct but not counted in the size.
  */
-struct mida {
-    /** Total size of the data in bytes */
-    size_t size;
-    /** Number of elements in the array */
-    size_t length;
-    /** Start of the actual array data (flexible array member) */
-    mida_byte data[1];
+struct mida_metadata {
+    MIDA_EXT_METADATA;
 };
 
 /**
- * @brief Allocates memory with MIDA metadata
+ * @brief Internal function that allocates memory with metadata
  *
- * Works like standard malloc but stores metadata about the allocated
- * array, allowing size and length information to be retrieved later.
+ * This is the core allocation function used by the mida_malloc and
+ * mida_ext_malloc macros. It allocates memory for both the metadata container
+ * and the actual data.
  *
- * @param element_size Size of each element in bytes
+ * @param container_size Size of the container structure
+ * @param mida_offset Offset to the metadata within the container
+ * @param element_size Size of each element in the array
  * @param count Number of elements to allocate
- * @return Pointer to the allocated memory, or NULL if allocation fails
+ * @return Pointer to the allocated data (not the container)
  */
-MIDA_API void *mida_malloc(size_t element_size, size_t count);
+MIDA_API void *__mida_malloc(const size_t container_size,
+                             const ptrdiff_t mida_offset,
+                             const size_t element_size,
+                             const size_t count);
 
 /**
- * @brief Allocates zeroed memory with MIDA metadata
+ * @def mida_ext_malloc(_container, _element_size, _count)
+ * @brief Allocates memory for an array with extended metadata
  *
- * Works like standard calloc but stores metadata about the allocated
- * array, allowing size and length information to be retrieved later.
+ * This macro allocates memory for an array of elements with the specified
+ * element size and count, and adds extended metadata using the provided
+ * container type.
  *
- * @param element_size Size of each element in bytes
+ * @param _container Type of the container structure
+ * @param _element_size Size of each element in bytes
+ * @param _count Number of elements to allocate
+ * @return Pointer to the allocated array (not the container)
+ */
+#define mida_ext_malloc(_container, _element_size, _count)                    \
+    __mida_malloc(sizeof(_container), offsetof(_container, size),             \
+                  _element_size, _count)
+
+/**
+ * @def mida_malloc(_element_size, _count)
+ * @brief Allocates memory for an array with standard metadata
+ *
+ * This macro allocates memory for an array of elements with the specified
+ * element size and count, and adds standard metadata.
+ *
+ * @param _element_size Size of each element in bytes
+ * @param _count Number of elements to allocate
+ * @return Pointer to the allocated array (not the container)
+ */
+#define mida_malloc(_element_size, _count)                                    \
+    mida_ext_malloc(struct mida_metadata, _element_size, _count)
+
+/**
+ * @brief Internal function that allocates and zeros memory with metadata
+ *
+ * This is the core allocation function used by the mida_calloc and
+ * mida_ext_calloc macros. It allocates and zeros memory for both the metadata
+ * container and the actual data.
+ *
+ * @param container_size Size of the container structure
+ * @param mida_offset Offset to the metadata within the container
+ * @param element_size Size of each element in the array
  * @param count Number of elements to allocate
- * @return Pointer to the allocated memory, or NULL if allocation fails
+ * @return Pointer to the allocated data (not the container)
  */
-MIDA_API void *mida_calloc(size_t element_size, size_t count);
+MIDA_API void *__mida_calloc(const size_t container_size,
+                             const ptrdiff_t mida_offset,
+                             const size_t element_size,
+                             const size_t count);
 
 /**
- * @brief Resizes memory with MIDA metadata
+ * @def mida_ext_calloc(_container, _element_size, _count)
+ * @brief Allocates and zeros memory for an array with extended metadata
  *
- * Works like standard realloc but preserves metadata about the array,
- * updating it to reflect the new size and length.
+ * This macro allocates and zeros memory for an array of elements with the
+ * specified element size and count, and adds extended metadata using the
+ * provided container type.
  *
- * @param ptr Pointer to memory previously allocated with MIDA functions, or
- * NULL
- * @param element_size Size of each element in bytes
- * @param count Number of elements in the resized array
- * @return Pointer to the resized memory, or NULL if reallocation fails
+ * @param _container Type of the container structure
+ * @param _element_size Size of each element in bytes
+ * @param _count Number of elements to allocate
+ * @return Pointer to the allocated array (not the container)
  */
-MIDA_API void *mida_realloc(void *ptr, size_t element_size, size_t count);
+#define mida_ext_calloc(_container, _element_size, _count)                    \
+    __mida_calloc(sizeof(_container), offsetof(_container, size),             \
+                  _element_size, _count)
 
 /**
- * @brief Frees memory allocated with MIDA functions
+ * @def mida_calloc(_element_size, _count)
+ * @brief Allocates and zeros memory for an array with standard metadata
  *
- * Works like standard free but accounts for the metadata structure.
+ * This macro allocates and zeros memory for an array of elements with the
+ * specified element size and count, and adds standard metadata.
  *
- * @param ptr Pointer to memory previously allocated with MIDA functions
+ * @param _element_size Size of each element in bytes
+ * @param _count Number of elements to allocate
+ * @return Pointer to the allocated array (not the container)
  */
-MIDA_API void mida_free(void *ptr);
+#define mida_calloc(_element_size, _count)                                    \
+    mida_ext_calloc(struct mida_metadata, _element_size, _count)
 
 /**
- * @brief Internal function to wrap existing data with MIDA metadata
+ * @brief Internal function that reallocates memory with metadata
  *
- * This function copies data into a bytemap buffer and initializes the
- * metadata structure at the beginning of the buffer.
+ * This is the core reallocation function used by the mida_realloc and
+ * mida_ext_realloc macros. It reallocates memory for both the metadata
+ * container and the actual data.
  *
- * @param data Pointer to the data to wrap
- * @param size Total size of the data in bytes
+ * @param container_size Size of the container structure
+ * @param container_offset Offset from the data pointer to the container
+ * @param mida_offset Offset to the metadata within the container
+ * @param base Pointer to the original data (not the container)
+ * @param element_size Size of each element in the array
+ * @param count New number of elements to allocate
+ * @return Pointer to the reallocated data (not the container)
+ */
+MIDA_API void *__mida_realloc(const size_t container_size,
+                              const ptrdiff_t container_offset,
+                              const ptrdiff_t mida_offset,
+                              void *base,
+                              const size_t element_size,
+                              const size_t count);
+
+/**
+ * @def mida_ext_realloc(_container, _base, _element_size, _count)
+ * @brief Reallocates memory for an array with extended metadata
+ *
+ * This macro reallocates memory for an array of elements with the specified
+ * element size and count, preserving the extended metadata.
+ *
+ * @param _container Type of the container structure
+ * @param _base Pointer to the original data (not the container)
+ * @param _element_size Size of each element in bytes
+ * @param _count New number of elements to allocate
+ * @return Pointer to the reallocated array (not the container)
+ */
+#define mida_ext_realloc(_container, _base, _element_size, _count)            \
+    __mida_realloc(sizeof(_container), -offsetof(_container, data),           \
+                   offsetof(_container, size), _base, _element_size, _count)
+
+/**
+ * @def mida_realloc(_base, _element_size, _count)
+ * @brief Reallocates memory for an array with standard metadata
+ *
+ * This macro reallocates memory for an array of elements with the specified
+ * element size and count, preserving the standard metadata.
+ *
+ * @param _base Pointer to the original data (not the container)
+ * @param _element_size Size of each element in bytes
+ * @param _count New number of elements to allocate
+ * @return Pointer to the reallocated array (not the container)
+ */
+#define mida_realloc(_base, _element_size, _count)                            \
+    mida_ext_realloc(struct mida_metadata, _base, _element_size, _count)
+
+/**
+ * @brief Internal function that frees memory with metadata
+ *
+ * This is the core deallocation function used by the mida_free and
+ * mida_ext_free macros. It frees memory for both the metadata container and
+ * the actual data.
+ *
+ * @param container_offset Offset from the data pointer to the container
+ * @param base Pointer to the data (not the container)
+ */
+MIDA_API void __mida_free(const ptrdiff_t container_offset, void *base);
+
+/**
+ * @def mida_ext_free(_container, _base)
+ * @brief Frees memory for an array with extended metadata
+ *
+ * This macro frees memory for an array with extended metadata.
+ *
+ * @param _container Type of the container structure
+ * @param _base Pointer to the data (not the container)
+ */
+#define mida_ext_free(_container, _base)                                      \
+    __mida_free(-offsetof(_container, data), _base)
+
+/**
+ * @def mida_free(_base)
+ * @brief Frees memory for an array with standard metadata
+ *
+ * This macro frees memory for an array with standard metadata.
+ *
+ * @param _base Pointer to the data (not the container)
+ */
+#define mida_free(_base) mida_ext_free(struct mida_metadata, _base)
+
+/**
+ * @brief Internal function that wraps existing data with metadata
+ *
+ * This is the core wrapping function used by the mida_wrap and mida_ext_wrap
+ * macros. It wraps existing data with metadata using a bytemap.
+ *
+ * @param mida_offset Offset to the metadata within the container
+ * @param data Pointer to the original data
+ * @param size Size of the data in bytes
  * @param length Number of elements in the data
- * @param bytemap Buffer to store the metadata and data copy
- * @return Pointer to the data portion of the bytemap
+ * @param bytemap Pointer to the bytemap buffer
+ * @return Pointer to the wrapped data (not the container)
  */
-MIDA_API void *_mida_wrap(void *data,
-                          const size_t size,
-                          const size_t length,
-                          mida_byte *const bytemap);
+MIDA_API void *__mida_wrap(const ptrdiff_t mida_offset,
+                           void *data,
+                           const size_t size,
+                           const size_t length,
+                           mida_byte *const bytemap);
+
+/**
+ * @def mida_ext_wrap(_container, _data, _bytemap)
+ * @brief Wraps existing data with extended metadata
+ *
+ * This macro wraps existing data with extended metadata using a bytemap.
+ *
+ * @param _container Type of the container structure
+ * @param _data Pointer to the original data
+ * @param _bytemap Pointer to the bytemap buffer created with MIDA_EXT_BYTEMAP
+ * @return Pointer to the wrapped data (not the container)
+ */
+#define mida_ext_wrap(_container, _data, _bytemap)                            \
+    __mida_wrap(offsetof(_container, size), _data,                            \
+                sizeof(_bytemap) - sizeof(_container),                        \
+                (sizeof(_bytemap) - sizeof(_container)) / sizeof *_data,      \
+                _bytemap)
 
 /**
  * @def mida_wrap(_data, _bytemap)
- * @brief Wraps existing data with MIDA metadata
+ * @brief Wraps existing data with standard metadata
  *
- * Creates a MIDA container for existing data by copying it to a bytemap
- * buffer and initializing the metadata.
+ * This macro wraps existing data with standard metadata using a bytemap.
  *
- * @param _data Data to wrap with metadata
- * @param _bytemap Bytemap buffer to store the metadata and data
- * @return Pointer to the data portion of the bytemap
+ * @param _data Pointer to the original data
+ * @param _bytemap Pointer to the bytemap buffer created with MIDA_BYTEMAP
+ * @return Pointer to the wrapped data (not the container)
  */
 #define mida_wrap(_data, _bytemap)                                            \
-    _mida_wrap(_data, sizeof(_bytemap) - sizeof(struct mida),                 \
-               (sizeof(_bytemap) - sizeof(struct mida)) / sizeof *_data,      \
-               _bytemap)
+    mida_ext_wrap(struct mida_metadata, _data, _bytemap)
 
 #ifdef MIDA_SUPPORTS_C99
 
 /**
+ * @def mida_ext_bytemap(_container, _size)
+ * @brief Creates a bytemap buffer with local storage, with the given size
+ *
+ * C99 only. Creates a compound literal for a bytemap of the specified size.
+ *
+ * @param _container The type of the container structure
+ * @param _size Size of the data that will be stored with metadata
+ * @return A compound literal initialized to zero
+ */
+#define mida_ext_bytemap(_container, _size)                                   \
+    (mida_byte[sizeof(_container) + _size])                                   \
+    {                                                                         \
+        0                                                                     \
+    }
+
+/**
  * @def mida_bytemap(_size)
- * @brief Creates a bytemap buffer with the given size
+ * @brief Creates a bytemap buffer with local storage, with the given size
  *
  * C99 only. Creates a compound literal for a bytemap of the specified size.
  *
  * @param _size Size of the data that will be stored with metadata
  * @return A compound literal initialized to zero
  */
-#define mida_bytemap(_size)                                                   \
-    (mida_byte[sizeof(struct mida) + _size])                                  \
-    {                                                                         \
-        0                                                                     \
-    }
+#define mida_bytemap(_size) mida_ext_bytemap(struct mida_metadata, _size)
+
+/**
+ * @def mida_ext_array(_container, _type, ...)
+ * @brief Creates an array with extended MIDA metadata
+ *
+ * C99 only. Creates an array of the specified type with values provided
+ * as a compound literal, and wraps it with extended MIDA metadata.
+ *
+ * @param _container The type of the container structure
+ * @param _type The type of array elements
+ * @param ... Compound literal array initialization values
+ * @return Pointer to the array with extended MIDA metadata
+ */
+#define mida_ext_array(_container, _type, ...)                                \
+    (_type *)(__mida_wrap(offsetof(_container, size), (_type[])__VA_ARGS__,   \
+                          sizeof((_type[])__VA_ARGS__),                       \
+                          sizeof((_type[])__VA_ARGS__) / sizeof(_type),       \
+                          mida_bytemap(sizeof((_type[])__VA_ARGS__))))
 
 /**
  * @def mida_array(_type, ...)
@@ -170,9 +382,22 @@ MIDA_API void *_mida_wrap(void *data,
  * @return Pointer to the array with MIDA metadata
  */
 #define mida_array(_type, ...)                                                \
-    (_type *)(_mida_wrap((_type[])__VA_ARGS__, sizeof((_type[])__VA_ARGS__),  \
-                         sizeof((_type[])__VA_ARGS__) / sizeof(_type),        \
-                         mida_bytemap(sizeof((_type[])__VA_ARGS__))))
+    mida_ext_array(struct mida_metadata, _type, __VA_ARGS__)
+
+/**
+ * @def mida_ext_struct(_container, _type, ...)
+ * @brief Creates a structure with extended MIDA metadata
+ *
+ * C99 only. Creates a structure of the specified type with values provided
+ * as a compound literal, and wraps it with extended MIDA metadata.
+ *
+ * @param _container The type of the container structure
+ * @param _type The structure type
+ * @param ... Compound literal structure initialization values
+ * @return Pointer to the structure with extended MIDA metadata
+ */
+#define mida_ext_struct(_container, _type, ...)                               \
+    mida_ext_array(_container, _type, { __VA_ARGS__ })
 
 /**
  * @def mida_struct(_type, ...)
@@ -190,6 +415,21 @@ MIDA_API void *_mida_wrap(void *data,
 #endif /* MIDA_SUPPORTS_C99 */
 
 /**
+ * @def mida_ext_container(_container, _base)
+ * @brief Retrieves the extended MIDA container structure for a given data
+ * pointer
+ *
+ * Given a pointer to data managed by MIDA, returns a pointer to the
+ * extended container structure that holds its metadata.
+ *
+ * @param _container The type of the container structure
+ * @param _base Pointer to data managed by MIDA
+ * @return Pointer to the extended container structure containing the metadata
+ */
+#define mida_ext_container(_container, _base)                                 \
+    ((_container *)((mida_byte *)(_base) - offsetof(_container, data)))
+
+/**
  * @def mida_container(_base)
  * @brief Retrieves the MIDA container structure for a given data pointer
  *
@@ -199,8 +439,18 @@ MIDA_API void *_mida_wrap(void *data,
  * @param _base Pointer to data managed by MIDA
  * @return Pointer to the mida structure containing the metadata
  */
-#define mida_container(_base)                                                 \
-    ((const struct mida *)((mida_byte *)(_base) - offsetof(struct mida, data)))
+#define mida_container(_base) mida_ext_container(struct mida_metadata, _base)
+
+/**
+ * @def mida_ext_sizeof(_container, _base)
+ * @brief Gets the total size of data managed by MIDA
+ *
+ * @param _container The type of the container structure
+ * @param _base Pointer to data managed by MIDA
+ * @return The total size of the data in bytes
+ */
+#define mida_ext_sizeof(_container, _base)                                    \
+    mida_ext_container(_container, _base)->size
 
 /**
  * @def mida_sizeof(_base)
@@ -209,7 +459,18 @@ MIDA_API void *_mida_wrap(void *data,
  * @param _base Pointer to data managed by MIDA
  * @return The total size of the data in bytes
  */
-#define mida_sizeof(_base) mida_container(_base)->size
+#define mida_sizeof(_base) mida_ext_sizeof(struct mida_metadata, _base)
+
+/**
+ * @def mida_ext_length(_container, _base)
+ * @brief Gets the number of elements in an array managed by MIDA
+ *
+ * @param _container The type of the container structure
+ * @param _base Pointer to data managed by MIDA
+ * @return The number of elements in the array
+ */
+#define mida_ext_length(_container, _base)                                    \
+    mida_ext_container(_container, _base)->length
 
 /**
  * @def mida_length(_base)
@@ -218,118 +479,85 @@ MIDA_API void *_mida_wrap(void *data,
  * @param _base Pointer to data managed by MIDA
  * @return The number of elements in the array
  */
-#define mida_length(_base) mida_container(_base)->length
+#define mida_length(_base) mida_ext_length(struct mida_metadata, _base)
 
 #ifndef MIDA_HEADER
 
 #include <string.h>
 #include <stdlib.h>
 
-/**
- * @brief Allocates memory with MIDA metadata
- *
- * Works like standard malloc but stores metadata about the allocated
- * array, allowing size and length information to be retrieved later.
- *
- * @param element_size Size of each element in bytes
- * @param count Number of elements to allocate
- * @return Pointer to the allocated memory, or NULL if allocation fails
- */
 MIDA_API void *
-mida_malloc(size_t element_size, size_t count)
+__mida_malloc(const size_t container_size,
+              const ptrdiff_t mida_offset,
+              const size_t element_size,
+              const size_t count)
 {
     const size_t data_size = element_size * count,
-                 total_size = sizeof(struct mida) - 1 + data_size;
-    struct mida *mida = malloc(total_size);
-    if (!mida) return NULL;
+                 total_size = container_size - 1 + data_size;
+    mida_byte *container = malloc(total_size);
+    struct mida_metadata *mida =
+        (struct mida_metadata *)(container + mida_offset);
+    if (!container) return NULL;
     mida->size = data_size;
     mida->length = count;
     return &mida->data;
 }
 
-/**
- * @brief Allocates zeroed memory with MIDA metadata
- *
- * Works like standard calloc but stores metadata about the allocated
- * array, allowing size and length information to be retrieved later.
- *
- * @param element_size Size of each element in bytes
- * @param count Number of elements to allocate
- * @return Pointer to the allocated memory, or NULL if allocation fails
- */
 MIDA_API void *
-mida_calloc(size_t element_size, size_t count)
+__mida_calloc(const size_t container_size,
+              const ptrdiff_t mida_offset,
+              const size_t element_size,
+              const size_t count)
 {
     const size_t data_size = element_size * count,
-                 total_size = sizeof(struct mida) - 1 + data_size;
-    struct mida *mida = calloc(1, total_size);
-    if (!mida) return NULL;
+                 total_size = container_size - 1 + data_size;
+    mida_byte *container = calloc(1, total_size);
+    struct mida_metadata *mida =
+        (struct mida_metadata *)(container + mida_offset);
+    if (!container) return NULL;
     mida->size = data_size;
     mida->length = count;
     return &mida->data;
 }
 
-/**
- * @brief Resizes memory with MIDA metadata
- *
- * Works like standard realloc but preserves metadata about the array,
- * updating it to reflect the new size and length.
- *
- * @param ptr Pointer to memory previously allocated with MIDA functions, or
- * NULL
- * @param element_size Size of each element in bytes
- * @param count Number of elements in the resized array
- * @return Pointer to the resized memory, or NULL if reallocation fails
- */
 MIDA_API void *
-mida_realloc(void *ptr, size_t element_size, size_t count)
+__mida_realloc(const size_t container_size,
+               const ptrdiff_t container_offset,
+               const ptrdiff_t mida_offset,
+               void *base,
+               const size_t element_size,
+               const size_t count)
 {
-    if (ptr) {
-        struct mida *mida = (struct mida *)mida_container(ptr);
+    if (base) {
         const size_t data_size = element_size * count,
-                     total_size = sizeof(struct mida) - 1 + data_size;
-        void *tmp = realloc(mida, total_size);
-        if (!tmp) return NULL;
-        mida = tmp;
+                     total_size = container_size - 1 + data_size;
+        mida_byte *original_container = (mida_byte *)base + container_offset;
+        mida_byte *container = realloc(original_container, total_size);
+        struct mida_metadata *mida =
+            (struct mida_metadata *)(container + mida_offset);
+        if (!container) return NULL;
         mida->size = data_size;
         mida->length = count;
         return &mida->data;
     }
-    return mida_malloc(element_size, count);
+    return __mida_malloc(container_size, mida_offset, element_size, count);
 }
 
-/**
- * @brief Frees memory allocated with MIDA functions
- *
- * Works like standard free but accounts for the metadata structure.
- *
- * @param ptr Pointer to memory previously allocated with MIDA functions
- */
 MIDA_API void
-mida_free(void *ptr)
+__mida_free(const ptrdiff_t container_offset, void *base)
 {
-    free((void *)mida_container(ptr));
+    free((mida_byte *)base + container_offset);
 }
 
-/**
- * @brief Internal function to wrap existing data with MIDA metadata
- *
- * This function copies data into a bytemap buffer and initializes the
- * metadata structure at the beginning of the buffer.
- *
- * @param data Pointer to the data to wrap
- * @param size Total size of the data in bytes
- * @param length Number of elements in the data
- * @param bytemap Buffer to store the metadata and data copy
- * @return Pointer to the data portion of the bytemap
- */
 MIDA_API void *
-_mida_wrap(void *data,
-           const size_t size,
-           const size_t length,
-           mida_byte *const bytemap)
+__mida_wrap(const ptrdiff_t mida_offset,
+            void *data,
+            const size_t size,
+            const size_t length,
+            mida_byte *const container)
 {
-    struct mida *mida = (struct mida *)bytemap;
+    struct mida_metadata *mida =
+        (struct mida_metadata *)(container + mida_offset);
     mida->size = size;
     mida->length = length;
     return memcpy(&mida->data, data, size);

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,7 @@ CC = cc
 
 EXES = test
 
-CFLAGS += -Wall -Wextra -Wpedantic -g -I$(TOP) -std=c99
+CFLAGS += -Wall -Wextra -Wpedantic -g -I$(TOP) -std=c99 -O0
 
 all: $(EXES)
 

--- a/test/test.c
+++ b/test/test.c
@@ -294,6 +294,263 @@ test_shallow_mida_deep_nesting(void)
     PASS();
 }
 
+TEST
+test_ext_malloc(void)
+{
+    // Define a custom metadata structure with additional fields
+    struct custom_metadata {
+        int flags;
+        char tag[16];
+        MIDA_EXT_METADATA;
+    };
+
+    // Allocate memory with extended metadata
+    int *array = mida_ext_malloc(struct custom_metadata, sizeof(int), 5);
+
+    // Access standard metadata
+    ASSERT_EQ(5, mida_ext_length(struct custom_metadata, array));
+    ASSERT_EQ(sizeof(int) * 5, mida_ext_sizeof(struct custom_metadata, array));
+
+    // Access custom metadata fields
+    struct custom_metadata *meta =
+        mida_ext_container(struct custom_metadata, array);
+    meta->flags = 42;
+    strcpy(meta->tag, "test-tag");
+
+    // Initialize array data
+    for (size_t i = 0; i < mida_ext_length(struct custom_metadata, array); i++)
+    {
+        array[i] = (int)i * 10;
+    }
+
+    // Verify data and metadata
+    ASSERT_EQ(0, array[0]);
+    ASSERT_EQ(10, array[1]);
+    ASSERT_EQ(40, array[4]);
+    ASSERT_EQ(42, meta->flags);
+    ASSERT_STR_EQ("test-tag", meta->tag);
+
+    mida_ext_free(struct custom_metadata, array);
+    PASS();
+}
+
+TEST
+test_ext_calloc(void)
+{
+    // Define a custom metadata structure with additional fields
+    struct custom_metadata {
+        int flags;
+        float version;
+        MIDA_EXT_METADATA;
+    };
+
+    // Allocate zeroed memory with extended metadata
+    int *array = mida_ext_calloc(struct custom_metadata, sizeof(int), 5);
+
+    // Access custom metadata fields
+    struct custom_metadata *meta =
+        mida_ext_container(struct custom_metadata, array);
+    meta->flags = 0x1234;
+    meta->version = 1.5f;
+
+    // Verify data is zeroed
+    for (size_t i = 0; i < mida_ext_length(struct custom_metadata, array); i++)
+    {
+        ASSERT_EQ(0, array[i]);
+    }
+
+    // Verify metadata
+    ASSERT_EQ(0x1234, meta->flags);
+    ASSERT_EQ_FMT(1.5f, meta->version, "%.1f");
+    ASSERT_EQ(5, mida_ext_length(struct custom_metadata, array));
+    ASSERT_EQ(sizeof(int) * 5, mida_ext_sizeof(struct custom_metadata, array));
+
+    mida_ext_free(struct custom_metadata, array);
+    PASS();
+}
+
+TEST
+test_ext_realloc(void)
+{
+    // Define a custom metadata structure with additional fields
+    struct custom_metadata {
+        char name[32];
+        MIDA_EXT_METADATA;
+    };
+
+    // Allocate memory with extended metadata
+    float *array = mida_ext_malloc(struct custom_metadata, sizeof(float), 3);
+
+    // Set custom metadata
+    struct custom_metadata *meta =
+        mida_ext_container(struct custom_metadata, array);
+    strcpy(meta->name, "extended-test");
+
+    // Initialize array data
+    array[0] = 1.1f;
+    array[1] = 2.2f;
+    array[2] = 3.3f;
+
+    // Resize array
+    array = mida_ext_realloc(struct custom_metadata, array, sizeof(float), 5);
+
+    // Verify data and metadata persisted
+    meta = mida_ext_container(struct custom_metadata, array);
+    ASSERT_EQ(5, mida_ext_length(struct custom_metadata, array));
+    ASSERT_EQ(sizeof(float) * 5,
+              mida_ext_sizeof(struct custom_metadata, array));
+    ASSERT_STR_EQ("extended-test", meta->name);
+    ASSERT_EQ_FMT(1.1f, array[0], "%.1f");
+    ASSERT_EQ_FMT(2.2f, array[1], "%.1f");
+    ASSERT_EQ_FMT(3.3f, array[2], "%.1f");
+
+    // Add data to new elements
+    array[3] = 4.4f;
+    array[4] = 5.5f;
+
+    // Resize down
+    array = mida_ext_realloc(struct custom_metadata, array, sizeof(float), 2);
+
+    // Verify data and metadata persisted
+    meta = mida_ext_container(struct custom_metadata, array);
+    ASSERT_EQ(2, mida_ext_length(struct custom_metadata, array));
+    ASSERT_EQ(sizeof(float) * 2,
+              mida_ext_sizeof(struct custom_metadata, array));
+    ASSERT_STR_EQ("extended-test", meta->name);
+    ASSERT_EQ_FMT(1.1f, array[0], "%.1f");
+    ASSERT_EQ_FMT(2.2f, array[1], "%.1f");
+
+    mida_ext_free(struct custom_metadata, array);
+    PASS();
+}
+
+TEST
+test_ext_bytemap_wrap(void)
+{
+    // Define a custom metadata structure with additional fields
+    struct custom_metadata {
+        unsigned long id;
+        MIDA_EXT_METADATA;
+    };
+
+    // Create original data
+    int data[] = { 10, 20, 30, 40, 50 };
+
+    // Create a bytemap for the extended metadata
+    MIDA_EXT_BYTEMAP(struct custom_metadata, bytemap, sizeof(data));
+
+    // Wrap the data with extended metadata
+    int *wrapped = mida_ext_wrap(struct custom_metadata, data, bytemap);
+
+    // Set and verify custom metadata
+    struct custom_metadata *meta =
+        mida_ext_container(struct custom_metadata, wrapped);
+    meta->id = 12345UL;
+
+    // Verify standard metadata and data
+    ASSERT_EQ(5, mida_ext_length(struct custom_metadata, wrapped));
+    ASSERT_EQ(sizeof(data), mida_ext_sizeof(struct custom_metadata, wrapped));
+    ASSERT_EQ(12345UL, meta->id);
+    ASSERT_EQ(10, wrapped[0]);
+    ASSERT_EQ(30, wrapped[2]);
+    ASSERT_EQ(50, wrapped[4]);
+
+    // No need to free wrapped data - it uses stack memory from bytemap
+    PASS();
+}
+
+#ifdef MIDA_SUPPORTS_C99
+TEST
+test_ext_compound_literals(void)
+{
+    // Define a custom metadata structure with additional fields
+    struct custom_metadata {
+        long timestamp;
+        MIDA_EXT_METADATA;
+    };
+
+    // Create an array with extended metadata using compound literals
+    int *array =
+        mida_ext_array(struct custom_metadata, int, { 5, 6, 7, 8, 9 });
+
+    // Set and access custom metadata
+    struct custom_metadata *meta =
+        mida_ext_container(struct custom_metadata, array);
+    meta->timestamp = 1625000000L;
+
+    // Verify standard metadata and data
+    ASSERT_EQ(5, mida_ext_length(struct custom_metadata, array));
+    ASSERT_EQ(sizeof(int) * 5, mida_ext_sizeof(struct custom_metadata, array));
+    ASSERT_EQ(1625000000L, meta->timestamp);
+    ASSERT_EQ(5, array[0]);
+    ASSERT_EQ(7, array[2]);
+    ASSERT_EQ(9, array[4]);
+
+    // Create a structure with extended metadata
+    struct point {
+        int x;
+        int y;
+    };
+
+    struct point *pt = mida_ext_struct(struct custom_metadata, struct point,
+                                       { .x = 100, .y = 200 });
+
+    // Access metadata and struct fields
+    meta = mida_ext_container(struct custom_metadata, pt);
+    meta->timestamp = 1625000001L;
+
+    ASSERT_EQ(1, mida_ext_length(struct custom_metadata, pt));
+    ASSERT_EQ(sizeof(struct point),
+              mida_ext_sizeof(struct custom_metadata, pt));
+    ASSERT_EQ(1625000001L, meta->timestamp);
+    ASSERT_EQ(100, pt->x);
+    ASSERT_EQ(200, pt->y);
+
+    // No need to free - these use stack memory in compound literals
+    PASS();
+}
+#endif
+
+TEST
+test_metadata_conversion(void)
+{
+    // Define a custom metadata structure
+    struct custom_metadata {
+        int category;
+        MIDA_EXT_METADATA;
+    };
+
+    // Allocate memory with extended metadata
+    int *array = mida_ext_malloc(struct custom_metadata, sizeof(int), 5);
+
+    // Set initial values
+    for (int i = 0; i < 5; i++) {
+        array[i] = i * 5;
+    }
+
+    // Set custom metadata
+    struct custom_metadata *ext_meta =
+        mida_ext_container(struct custom_metadata, array);
+    ext_meta->category = 42;
+
+    // Access the metadata through both interfaces
+    ASSERT_EQ(5, mida_ext_length(struct custom_metadata, array));
+    ASSERT_EQ(42, ext_meta->category);
+
+    // Convert to standard metadata
+    const struct mida_metadata *std_meta =
+        (const struct mida_metadata *)((char *)ext_meta
+                                       + offsetof(struct custom_metadata,
+                                                  size));
+
+    // Access standard metadata fields
+    ASSERT_EQ(5, std_meta->length);
+    ASSERT_EQ(sizeof(int) * 5, std_meta->size);
+
+    mida_ext_free(struct custom_metadata, array);
+    PASS();
+}
+
 SUITE(suite_compound_literals)
 {
     RUN_TEST(test_init_compound_literals);
@@ -312,6 +569,18 @@ SUITE(suite_stdlib)
     RUN_TEST(test_realloc_null);
 }
 
+SUITE(suite_extended_metadata)
+{
+    RUN_TEST(test_ext_malloc);
+    RUN_TEST(test_ext_calloc);
+    RUN_TEST(test_ext_realloc);
+    RUN_TEST(test_ext_bytemap_wrap);
+#ifdef MIDA_SUPPORTS_C99
+    RUN_TEST(test_ext_compound_literals);
+#endif
+    RUN_TEST(test_metadata_conversion);
+}
+
 GREATEST_MAIN_DEFS();
 
 int
@@ -320,5 +589,6 @@ main(int argc, char *argv[])
     GREATEST_MAIN_BEGIN();
     RUN_SUITE(suite_compound_literals);
     RUN_SUITE(suite_stdlib);
+    RUN_SUITE(suite_extended_metadata);
     GREATEST_MAIN_END();
 }


### PR DESCRIPTION
This pull request introduces support for extended metadata in the MIDA library, allowing users to define custom metadata fields alongside standard metadata. Key changes include updates to the documentation, new API functions and macros, extended memory management features, and comprehensive test coverage for the new functionality.

### Extended Metadata Support

* **Documentation Enhancements**:
  - Added a new section in `README.md` explaining how to use extended metadata, including examples for defining custom metadata structures, accessing metadata, and using extended functions like `mida_ext_malloc` and `mida_ext_free`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R105-R131) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R148-R168) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R238-R265) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R274-R286)
  - Updated memory layout diagrams to include the extended metadata structure.

* **New API Functions and Macros**:
  - Introduced extended memory management functions (`mida_ext_malloc`, `mida_ext_calloc`, `mida_ext_realloc`, `mida_ext_free`) and metadata access macros (`mida_ext_length`, `mida_ext_sizeof`, `mida_ext_container`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R238-R265) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R274-R286)
  - Added macros for creating arrays and structures with extended metadata (`mida_ext_array`, `mida_ext_struct`, `MIDA_EXT_METADATA`).

### Testing Enhancements

* **New Test Cases**:
  - Added extensive tests in `test/test.c` to validate extended metadata functionality, including allocation, reallocation, wrapping, and metadata conversion. Tests cover both standard and extended metadata access.
  - Introduced a new test suite `suite_extended_metadata` to group all tests related to extended metadata. [[1]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651R572-R583) [[2]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651R592)

### Build Configuration

* **Testing Build Flags**:
  - Updated `test/Makefile` to include the `-O0` flag for easier debugging during testing.