### PR TITLE
Fix data alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ You can define custom metadata structures with additional fields:
 ```c
 // Define a custom metadata structure with extra fields
 struct my_metadata {
-    int flags;          // Custom field added before MIDA_EXT_METADATA
-    char tag[16];       // Custom field added before MIDA_EXT_METADATA
-    MIDA_EXT_METADATA;  // Must be the last field in the struct
+    MIDA_EXT_METADATA;  // Must be the first field in the struct
+    int flags;          // Custom field added after MIDA_EXT_METADATA
+    char tag[16];       // Custom field added after MIDA_EXT_METADATA
 };
 
 // Use extended malloc to allocate with custom metadata

--- a/test/test.c
+++ b/test/test.c
@@ -299,9 +299,9 @@ test_ext_malloc(void)
 {
     // Define a custom metadata structure with additional fields
     struct custom_metadata {
+        MIDA_EXT_METADATA;
         int flags;
         char tag[16];
-        MIDA_EXT_METADATA;
     };
 
     // Allocate memory with extended metadata
@@ -339,9 +339,9 @@ test_ext_calloc(void)
 {
     // Define a custom metadata structure with additional fields
     struct custom_metadata {
+        MIDA_EXT_METADATA;
         int flags;
         float version;
-        MIDA_EXT_METADATA;
     };
 
     // Allocate zeroed memory with extended metadata
@@ -374,8 +374,8 @@ test_ext_realloc(void)
 {
     // Define a custom metadata structure with additional fields
     struct custom_metadata {
-        char name[32];
         MIDA_EXT_METADATA;
+        char name[32];
     };
 
     // Allocate memory with extended metadata
@@ -429,8 +429,8 @@ test_ext_bytemap_wrap(void)
 {
     // Define a custom metadata structure with additional fields
     struct custom_metadata {
-        unsigned long id;
         MIDA_EXT_METADATA;
+        unsigned long id;
     };
 
     // Create original data
@@ -465,8 +465,8 @@ test_ext_compound_literals(void)
 {
     // Define a custom metadata structure with additional fields
     struct custom_metadata {
-        long timestamp;
         MIDA_EXT_METADATA;
+        long timestamp;
     };
 
     // Create an array with extended metadata using compound literals
@@ -516,8 +516,8 @@ test_metadata_conversion(void)
 {
     // Define a custom metadata structure
     struct custom_metadata {
-        int category;
         MIDA_EXT_METADATA;
+        int category;
     };
 
     // Allocate memory with extended metadata


### PR DESCRIPTION
Thanks to u/niduser457 for their thorough analysis!

This pull request refactors the MIDA library to simplify metadata handling and improve memory allocation functions. Key changes include removing reliance on offsets for metadata access, introducing helper functions for container and data pointer conversions, and updating macros and test cases to align with the new structure.

### Refactoring metadata handling:

* Updated `MIDA_EXT_METADATA` to remove the flexible array member `data` and clarified that the actual data follows the metadata structure in memory. This change simplifies memory layout and avoids reliance on flexible array members.
* Introduced helper functions `_mida_data_from_container` and `_mida_container_from_data` to convert between container and data pointers, replacing offset-based calculations.

### Simplifying memory allocation functions:

* Removed `mida_offset` and `container_offset` parameters from `__mida_malloc`, `__mida_calloc`, `__mida_realloc`, and `__mida_free`. These functions now use the container size directly. [[1]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL123-R114) [[2]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL148-L154) [[3]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL197-L206) [[4]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL250-R234)
* Updated macros (`mida_ext_malloc`, `mida_ext_calloc`, `mida_ext_realloc`, `mida_ext_free`) to align with the simplified function signatures. [[1]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL123-R114) [[2]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL172-R160) [[3]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL225-R208) [[4]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL264-R245)

### Updating wrapping and conversion logic:

* Modified `__mida_wrap` to use `container_size` instead of `mida_offset` for metadata placement. Updated related macros (`mida_ext_wrap`, `mida_ext_array`, `mida_ext_container`) accordingly. [[1]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL283-R270) [[2]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL308-R290) [[3]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL368-R351) [[4]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL430-R410)

### Adjustments to test cases:

* Updated test cases in `test/test.c` to reflect the new metadata structure and ensure `MIDA_EXT_METADATA` is placed at the beginning of custom metadata structs. [[1]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651R302-L304) [[2]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651R342-L344) [[3]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L377-R378) [[4]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L432-R433) [[5]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L468-R469) [[6]](diffhunk://#diff-e259e818dba4950aedfda772de80aaf4737e6e24a364f543f398597aeaa84651L519-R520)