### PR TITLE
Rewrite with emphasis to metadata injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 !Makefile
 !README.md
 !LICENSE
+!examples
 !test
 !.clang-format

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,10 @@
+# Ignore all
+*
+# But these
+!.gitignore
+!Makefile
+!array_length.c
+!complex_metadata.c
+!file_metadata.c
+!nested_metadata.c
+!timestamp.c

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,13 @@
+TOP = ..
+
+CC = gcc
+CFLAGS = -Wall -Wextra -g -I$(TOP) -O0
+
+EXES = array_length timestamp file_metadata complex_metadata nested_metadata
+
+all: $(EXES)
+
+clean:
+	@ rm -f $(EXES)
+
+.PHONY: all clean

--- a/examples/array_length.c
+++ b/examples/array_length.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include "../mida.h"
+
+// Define a custom metadata structure for arrays
+typedef struct array_metadata {
+    size_t length;
+} ArrayMD;
+
+int
+main()
+{
+    // Allocate an array with length metadata
+    int *numbers = mida_malloc(ArrayMD, sizeof(int), 5);
+
+    // Set metadata
+    ArrayMD *meta = MIDA(ArrayMD, numbers);
+    meta->length = 5;
+
+    // Initialize the array
+    for (size_t i = 0; i < meta->length; i++) {
+        numbers[i] = i * 10;
+    }
+
+    // Print the array with its length
+    printf("Array length: %zu\n", meta->length);
+    printf("Array contents: ");
+    for (size_t i = 0; i < meta->length; i++) {
+        printf("%d ", numbers[i]);
+    }
+    printf("\n");
+
+    // Free the array
+    mida_free(ArrayMD, numbers);
+
+    return 0;
+}

--- a/examples/complex_metadata.c
+++ b/examples/complex_metadata.c
@@ -1,0 +1,87 @@
+#include <stdio.h>
+#include <time.h>
+#include <string.h>
+#include "../mida.h"
+
+// Define a custom metadata structure with various fields
+typedef struct record_metadata {
+    size_t record_count;
+    unsigned int version;
+    char author[32];
+    time_t timestamp;
+    int flags;
+} RecordMD;
+
+// Define our custom data structure
+typedef struct person {
+    char name[64];
+    int age;
+    float salary;
+} Person;
+
+// Helper to print record flags
+void
+print_flags(int flags)
+{
+    printf("Flags: ");
+    if (flags & 0x1) printf("ACTIVE ");
+    if (flags & 0x2) printf("VERIFIED ");
+    if (flags & 0x4) printf("ADMIN ");
+    if (flags & 0x8) printf("PREMIUM ");
+    printf("\n");
+}
+
+int
+main()
+{
+    // Create an array of Person structures with metadata
+    Person *employees = mida_malloc(RecordMD, sizeof(Person), 3);
+
+    // Set metadata
+    RecordMD *meta = MIDA(RecordMD, employees);
+    meta->record_count = 3;
+    meta->version = 1;
+    strcpy(meta->author, "John Doe");
+    meta->timestamp = time(NULL);
+    meta->flags = 0x3; // ACTIVE | VERIFIED
+
+    // Fill in the employee records
+    strcpy(employees[0].name, "Alice Johnson");
+    employees[0].age = 32;
+    employees[0].salary = 75000.0f;
+
+    strcpy(employees[1].name, "Bob Smith");
+    employees[1].age = 45;
+    employees[1].salary = 92000.0f;
+
+    strcpy(employees[2].name, "Carol Davis");
+    employees[2].age = 28;
+    employees[2].salary = 68000.0f;
+
+    // Print metadata about the record set
+    printf("Employee Records (Version %u)\n", meta->version);
+    printf("Record Count: %zu\n", meta->record_count);
+    printf("Author: %s\n", meta->author);
+
+    char time_str[64];
+    struct tm *timeinfo = localtime(&meta->timestamp);
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", timeinfo);
+    printf("Timestamp: %s\n", time_str);
+
+    print_flags(meta->flags);
+
+    // Print the employee records
+    printf("\nEmployee Records:\n");
+    printf("%-20s %-5s %-10s\n", "Name", "Age", "Salary");
+    printf("---------------------------------------\n");
+
+    for (size_t i = 0; i < meta->record_count; i++) {
+        printf("%-20s %-5d $%-10.2f\n", employees[i].name, employees[i].age,
+               employees[i].salary);
+    }
+
+    // Free the records
+    mida_free(RecordMD, employees);
+
+    return 0;
+}

--- a/examples/file_metadata.c
+++ b/examples/file_metadata.c
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include <time.h>
+#include <string.h>
+#include "../mida.h"
+
+// Define file-like metadata
+typedef struct file_metadata {
+    char filename[64];
+    char mime_type[32];
+    size_t size;
+    time_t created;
+    unsigned int permissions;
+} FileMD;
+
+int
+main()
+{
+    // Create a buffer with file metadata
+    const char *content = "This is some example file content.\n"
+                          "It has multiple lines of text.\n"
+                          "It could represent a document or any other file.";
+
+    // Create a bytemap for our metadata and data
+    MIDA_BYTEMAP(FileMD, bytemap, strlen(content) + 1);
+
+    // Wrap the data with metadata
+    char *file_data = mida_wrap(FileMD, (void *)content, bytemap);
+
+    // Set the metadata
+    FileMD *meta = MIDA(FileMD, file_data);
+    strcpy(meta->filename, "example.txt");
+    strcpy(meta->mime_type, "text/plain");
+    meta->size = strlen(content);
+    meta->created = time(NULL);
+    meta->permissions = 0644; // rw-r--r--
+
+    // Print the file information
+    printf("File: %s\n", meta->filename);
+    printf("MIME Type: %s\n", meta->mime_type);
+    printf("Size: %zu bytes\n", meta->size);
+
+    char time_str[64];
+    struct tm *timeinfo = localtime(&meta->created);
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", timeinfo);
+    printf("Created: %s\n", time_str);
+
+    printf("Permissions: %o\n", meta->permissions);
+
+    printf("\nContent:\n%s\n", file_data);
+
+    // No need to free, as we used a bytemap with automatic storage
+
+    return 0;
+}

--- a/examples/nested_metadata.c
+++ b/examples/nested_metadata.c
@@ -1,0 +1,107 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../mida.h"
+
+// Different metadata for different levels
+typedef struct string_metadata {
+    size_t length;
+} StrMD;
+
+typedef struct array_metadata {
+    size_t count;
+    char description[64];
+} ArrayMD;
+
+typedef struct object_metadata {
+    char type[32];
+    int id;
+} ObjMD;
+
+// Define document structure
+typedef struct document {
+    char *title;
+    int *page_lengths;
+    struct document *related_doc;
+} Document;
+
+int
+main()
+{
+    // Create a document with different metadata for each component
+    Document *doc = mida_malloc(ObjMD, sizeof(Document), 1);
+
+    // Set metadata for document
+    ObjMD *doc_meta = MIDA(ObjMD, doc);
+    strcpy(doc_meta->type, "Report");
+    doc_meta->id = 101;
+
+    // Create title with string metadata
+    doc->title = mida_malloc(StrMD, sizeof(char), 22);
+    strcpy(doc->title, "Annual Financial Report");
+    StrMD *title_meta = MIDA(StrMD, doc->title);
+    title_meta->length = strlen(doc->title);
+
+    // Create page lengths array with array metadata
+    doc->page_lengths = mida_malloc(ArrayMD, sizeof(int), 5);
+    doc->page_lengths[0] = 2; // Summary
+    doc->page_lengths[1] = 10; // Introduction
+    doc->page_lengths[2] = 25; // Financial Data
+    doc->page_lengths[3] = 15; // Analysis
+    doc->page_lengths[4] = 5; // Conclusion
+
+    ArrayMD *pages_meta = MIDA(ArrayMD, doc->page_lengths);
+    pages_meta->count = 5;
+    strcpy(pages_meta->description, "Pages per section");
+
+    // Create related document with object metadata
+    doc->related_doc = mida_malloc(ObjMD, sizeof(Document), 1);
+
+    ObjMD *related_meta = MIDA(ObjMD, doc->related_doc);
+    strcpy(related_meta->type, "Appendix");
+    related_meta->id = 102;
+
+    // Create title for related document
+    doc->related_doc->title = mida_malloc(StrMD, sizeof(char), 25);
+    strcpy(doc->related_doc->title, "Financial Report Appendix");
+    StrMD *rel_title_meta = MIDA(StrMD, doc->related_doc->title);
+    rel_title_meta->length = strlen(doc->related_doc->title);
+
+    // No pages or related docs for the appendix
+    doc->related_doc->page_lengths = NULL;
+    doc->related_doc->related_doc = NULL;
+
+    // Print document information using metadata
+    printf("Document Type: %s (ID: %d)\n", doc_meta->type, doc_meta->id);
+    printf("Title: %s (Length: %zu characters)\n", doc->title,
+           title_meta->length);
+
+    printf("\nSections (%s):\n", pages_meta->description);
+    const char *sections[] = { "Summary", "Introduction", "Financial Data",
+                               "Analysis", "Conclusion" };
+    for (size_t i = 0; i < pages_meta->count; i++) {
+        printf("  %s: %d pages\n", sections[i], doc->page_lengths[i]);
+    }
+
+    // Calculate total pages
+    int total = 0;
+    for (size_t i = 0; i < pages_meta->count; i++) {
+        total += doc->page_lengths[i];
+    }
+    printf("Total pages: %d\n", total);
+
+    // Print related document information
+    printf("\nRelated Document:\n");
+    printf("Type: %s (ID: %d)\n", related_meta->type, related_meta->id);
+    printf("Title: %s (Length: %zu characters)\n", doc->related_doc->title,
+           rel_title_meta->length);
+
+    // Free all allocated memory
+    mida_free(StrMD, doc->related_doc->title);
+    mida_free(ObjMD, doc->related_doc);
+    mida_free(ArrayMD, doc->page_lengths);
+    mida_free(StrMD, doc->title);
+    mida_free(ObjMD, doc);
+
+    return 0;
+}

--- a/examples/timestamp.c
+++ b/examples/timestamp.c
@@ -1,0 +1,59 @@
+#include <stdio.h>
+#include <time.h>
+#include "../mida.h"
+
+// Define a custom metadata structure with timestamp
+typedef struct timestamp_metadata {
+    time_t created;
+    time_t modified;
+} TimestampMD;
+
+// Helper function to print timestamps
+void
+print_time(const char *label, time_t timestamp)
+{
+    char time_str[64];
+    struct tm *timeinfo = localtime(&timestamp);
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", timeinfo);
+    printf("%s: %s\n", label, time_str);
+}
+
+int
+main()
+{
+    // Create a structure with timestamp metadata
+    struct data {
+        int value;
+        char name[32];
+    };
+
+    // Allocate and initialize the structure
+    struct data *record = mida_malloc(TimestampMD, sizeof(struct data), 1);
+    record->value = 42;
+    strcpy(record->name, "Example Data");
+
+    // Set metadata
+    TimestampMD *meta = MIDA(TimestampMD, record);
+    meta->created = time(NULL);
+    meta->modified = meta->created;
+
+    // Print initial information
+    printf("Record: %s (value: %d)\n", record->name, record->value);
+    print_time("Created", meta->created);
+    print_time("Modified", meta->modified);
+
+    // Modify the record and update the timestamp
+    printf("\nModifying the record...\n");
+    record->value = 100;
+    meta->modified = time(NULL);
+
+    // Print updated information
+    printf("Record: %s (value: %d)\n", record->name, record->value);
+    print_time("Created", meta->created);
+    print_time("Modified", meta->modified);
+
+    // Free the record
+    mida_free(TimestampMD, record);
+
+    return 0;
+}

--- a/mida.h
+++ b/mida.h
@@ -6,9 +6,10 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include <stddef.h>
+#include <stdlib.h>
 
 #if __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
-#define MIDA_SUPPORTS_C99
+#define MIDA_WITH_C99
 #endif /* __STDC_VERSION__ */
 
 #ifdef MIDA_STATIC
@@ -27,7 +28,7 @@ extern "C" {
 typedef char mida_byte;
 
 /**
- * @def MIDA_EXT_BYTEMAP(_container, _bytemap, _size)
+ * @def MIDA_BYTEMAP(_container, _bytemap, _size)
  * @brief Defines an extended bytemap for storing metadata
  *
  * Creates a bytemap buffer with local storage, of the appropriate size to hold
@@ -35,70 +36,17 @@ typedef char mida_byte;
  *
  * @param _container Name of the container structure
  * @param _bytemap Name of the bytemap array
- * @param _size Size of the data that will be stored with metadata
+ * @param _sizeof Size of the data that will be stored with metadata
  */
-#define MIDA_EXT_BYTEMAP(_container, _bytemap, _size)                         \
-    mida_byte(_bytemap)[sizeof(_container) + (_size)]
+#define MIDA_BYTEMAP(_container, _bytemap, _sizeof)                           \
+    mida_byte(_bytemap)[sizeof(_container) + (_sizeof)]
 
-/**
- * @def MIDA_BYTEMAP(_bytemap, _size)
- * @brief Defines a bytemap for storing metadata
- *
- * Creates a bytemap buffer with local storage, of the appropriate size to hold
- * both the metadata structure and the user data.
- *
- * @param _bytemap Name of the bytemap array
- * @param _size Size of the data that will be stored with metadata
- */
-#define MIDA_BYTEMAP(_bytemap, _size)                                         \
-    MIDA_EXT_BYTEMAP(struct mida_metadata, _bytemap, _size)
-
-/**
- * @def MIDA_EXT_METADATA
- * @brief Defines the metadata structure for MIDA
- * @note When using this macro for extended metadata, ensure that the
- * macro is placed at the start of the struct definition.
- *
- * This macro defines the metadata fields that are used by MIDA to track
- * array size and length. The actual data will follow immediately after
- * the structure in memory.
- */
-#define MIDA_EXT_METADATA                                                     \
-    /** Total size of the data in bytes */                                    \
-    size_t size;                                                              \
-    /** Number of elements in the array */                                    \
-    size_t length
-
-/**
- * @struct mida_metadata
- * @brief Structure that holds metadata about a structure
- *
- * This structure is prefixed to all data managed by MIDA. It stores
- * information about the total size and number of elements in the array.
- * The actual data immediately follows this structure in memory.
- */
-struct mida_metadata {
-    MIDA_EXT_METADATA;
-};
-
-/**
- * @brief Internal function that allocates memory with metadata
- *
- * This is the core allocation function used by the mida_malloc and
- * mida_ext_malloc macros. It allocates memory for both the metadata container
- * and the actual data.
- *
- * @param container_size Size of the container structure
- * @param element_size Size of each element in the array
- * @param count Number of elements to allocate
- * @return Pointer to the allocated data (not the container)
- */
 MIDA_API void *__mida_malloc(const size_t container_size,
                              const size_t element_size,
                              const size_t count);
 
 /**
- * @def mida_ext_malloc(_container, _element_size, _count)
+ * @def mida_malloc(_container, _element_size, _count)
  * @brief Allocates memory for an array with extended metadata
  *
  * This macro allocates memory for an array of elements with the specified
@@ -110,44 +58,18 @@ MIDA_API void *__mida_malloc(const size_t container_size,
  * @param _count Number of elements to allocate
  * @return Pointer to the allocated array (not the container)
  */
-#define mida_ext_malloc(_container, _element_size, _count)                    \
+#define mida_malloc(_container, _element_size, _count)                        \
     __mida_malloc(sizeof(_container), _element_size, _count)
 
-/**
- * @def mida_malloc(_element_size, _count)
- * @brief Allocates memory for an array with standard metadata
- *
- * This macro allocates memory for an array of elements with the specified
- * element size and count, and adds standard metadata.
- *
- * @param _element_size Size of each element in bytes
- * @param _count Number of elements to allocate
- * @return Pointer to the allocated array (not the container)
- */
-#define mida_malloc(_element_size, _count)                                    \
-    mida_ext_malloc(struct mida_metadata, _element_size, _count)
-
-/**
- * @brief Internal function that allocates and zeros memory with metadata
- *
- * This is the core allocation function used by the mida_calloc and
- * mida_ext_calloc macros. It allocates and zeros memory for both the metadata
- * container and the actual data.
- *
- * @param container_size Size of the container structure
- * @param element_size Size of each element in the array
- * @param count Number of elements to allocate
- * @return Pointer to the allocated data (not the container)
- */
 MIDA_API void *__mida_calloc(const size_t container_size,
                              const size_t element_size,
                              const size_t count);
 
 /**
- * @def mida_ext_calloc(_container, _element_size, _count)
+ * @def mida_calloc(_container, _element_size, _count)
  * @brief Allocates and zeros memory for an array with extended metadata
  *
- * This macro allocates and zeros memory for an array of elements with the
+ * This function allocates and zeros memory for an array of elements with the
  * specified element size and count, and adds extended metadata using the
  * provided container type.
  *
@@ -156,43 +78,16 @@ MIDA_API void *__mida_calloc(const size_t container_size,
  * @param _count Number of elements to allocate
  * @return Pointer to the allocated array (not the container)
  */
-#define mida_ext_calloc(_container, _element_size, _count)                    \
+#define mida_calloc(_container, _element_size, _count)                        \
     __mida_calloc(sizeof(_container), _element_size, _count)
 
-/**
- * @def mida_calloc(_element_size, _count)
- * @brief Allocates and zeros memory for an array with standard metadata
- *
- * This macro allocates and zeros memory for an array of elements with the
- * specified element size and count, and adds standard metadata.
- *
- * @param _element_size Size of each element in bytes
- * @param _count Number of elements to allocate
- * @return Pointer to the allocated array (not the container)
- */
-#define mida_calloc(_element_size, _count)                                    \
-    mida_ext_calloc(struct mida_metadata, _element_size, _count)
-
-/**
- * @brief Internal function that reallocates memory with metadata
- *
- * This is the core reallocation function used by the mida_realloc and
- * mida_ext_realloc macros. It reallocates memory for both the metadata
- * container and the actual data.
- *
- * @param container_size Size of the container structure
- * @param base Pointer to the original data (not the container)
- * @param element_size Size of each element in the array
- * @param count New number of elements to allocate
- * @return Pointer to the reallocated data (not the container)
- */
 MIDA_API void *__mida_realloc(const size_t container_size,
                               void *base,
                               const size_t element_size,
                               const size_t count);
 
 /**
- * @def mida_ext_realloc(_container, _base, _element_size, _count)
+ * @def mida_realloc(_container, _base, _element_size, _count)
  * @brief Reallocates memory for an array with extended metadata
  *
  * This macro reallocates memory for an array of elements with the specified
@@ -204,37 +99,11 @@ MIDA_API void *__mida_realloc(const size_t container_size,
  * @param _count New number of elements to allocate
  * @return Pointer to the reallocated array (not the container)
  */
-#define mida_ext_realloc(_container, _base, _element_size, _count)            \
+#define mida_realloc(_container, _base, _element_size, _count)                \
     __mida_realloc(sizeof(_container), _base, _element_size, _count)
 
 /**
- * @def mida_realloc(_base, _element_size, _count)
- * @brief Reallocates memory for an array with standard metadata
- *
- * This macro reallocates memory for an array of elements with the specified
- * element size and count, preserving the standard metadata.
- *
- * @param _base Pointer to the original data (not the container)
- * @param _element_size Size of each element in bytes
- * @param _count New number of elements to allocate
- * @return Pointer to the reallocated array (not the container)
- */
-#define mida_realloc(_base, _element_size, _count)                            \
-    mida_ext_realloc(struct mida_metadata, _base, _element_size, _count)
-
-/**
- * @brief Internal function that frees memory with metadata
- *
- * This is the core deallocation function used by the mida_free and
- * mida_ext_free macros. It frees memory for both the metadata container and
- * the actual data.
- *
- * @param base Pointer to the data (not the container)
- */
-MIDA_API void __mida_free(const size_t container_size, void *base);
-
-/**
- * @def mida_ext_free(_container, _base)
+ * @def mida_free(_container, _base)
  * @brief Frees memory for an array with extended metadata
  *
  * This macro frees memory for an array with extended metadata.
@@ -242,131 +111,84 @@ MIDA_API void __mida_free(const size_t container_size, void *base);
  * @param _container Type of the container structure
  * @param _base Pointer to the data (not the container)
  */
-#define mida_ext_free(_container, _base) __mida_free(sizeof(_container), _base)
+#define mida_free(_container, _base) free(MIDA(_container, _base));
+
+MIDA_API void *__mida_nwrap(const size_t container_size,
+                            void *data,
+                            const size_t size,
+                            mida_byte *const container);
 
 /**
- * @def mida_free(_base)
- * @brief Frees memory for an array with standard metadata
+ * @def mida_nwrap(_container, _data, _bytemap, _bytemap_size)
+ * @brief Wraps existing data with extended metadata
  *
- * This macro frees memory for an array with standard metadata.
+ * This macro wraps existing data with extended metadata using a bytemap,
+ *  includes a bytemap_size parameter for fine-tuning the size of the
+ *  bytemap buffer.
  *
- * @param _base Pointer to the data (not the container)
- */
-#define mida_free(_base) mida_ext_free(struct mida_metadata, _base)
-
-/**
- * @brief Internal function that wraps existing data with metadata
- *
- * This is the core wrapping function used by the mida_wrap and mida_ext_wrap
- * macros. It wraps existing data with metadata using a bytemap.
- *
- * @param container_size Size of the container structure
- * @param data Pointer to the original data
- * @param size Size of the data in bytes
- * @param length Number of elements in the data
- * @param bytemap Pointer to the bytemap buffer
+ * @param _container Type of the container structure
+ * @param _data Pointer to the original data
+ * @param _bytemap Pointer to the bytemap buffer created with MIDA_BYTEMAP
+ * @param _bytemap_size Size of the bytemap buffer
  * @return Pointer to the wrapped data (not the container)
  */
-MIDA_API void *__mida_wrap(const size_t container_size,
-                           void *data,
-                           const size_t size,
-                           const size_t length,
-                           mida_byte *const bytemap);
+#define mida_nwrap(_container, _data, _bytemap, _bytemap_size)                \
+    __mida_nwrap(sizeof(_container), _data,                                   \
+                 _bytemap_size - sizeof(_container), _bytemap)
 
 /**
- * @def mida_ext_wrap(_container, _data, _bytemap)
+ * @def mida_wrap(_container, _data, _bytemap)
  * @brief Wraps existing data with extended metadata
  *
  * This macro wraps existing data with extended metadata using a bytemap.
  *
  * @param _container Type of the container structure
  * @param _data Pointer to the original data
- * @param _bytemap Pointer to the bytemap buffer created with MIDA_EXT_BYTEMAP
- * @return Pointer to the wrapped data (not the container)
- */
-#define mida_ext_wrap(_container, _data, _bytemap)                            \
-    __mida_wrap(                                                              \
-        sizeof(_container), _data, sizeof(_bytemap) - sizeof(_container),     \
-        (sizeof(_bytemap) - sizeof(_container)) / sizeof *_data, _bytemap)
-
-/**
- * @def mida_wrap(_data, _bytemap)
- * @brief Wraps existing data with standard metadata
- *
- * This macro wraps existing data with standard metadata using a bytemap.
- *
- * @param _data Pointer to the original data
  * @param _bytemap Pointer to the bytemap buffer created with MIDA_BYTEMAP
  * @return Pointer to the wrapped data (not the container)
  */
-#define mida_wrap(_data, _bytemap)                                            \
-    mida_ext_wrap(struct mida_metadata, _data, _bytemap)
+#define mida_wrap(_container, _data, _bytemap)                                \
+    mida_nwrap(_container, _data, _bytemap, sizeof(_bytemap))
 
-#ifdef MIDA_SUPPORTS_C99
+#ifdef MIDA_WITH_C99
 
 /**
- * @def mida_ext_bytemap(_container, _size)
+ * @def mida_bytemap(_container, _size)
  * @brief Creates a bytemap buffer with local storage, with the given size
  *
  * C99 only. Creates a compound literal for a bytemap of the specified size.
  *
  * @param _container The type of the container structure
- * @param _size Size of the data that will be stored with metadata
+ * @param _sizeof Size of the data that will be stored with metadata
  * @return A compound literal initialized to zero
  */
-#define mida_ext_bytemap(_container, _size)                                   \
-    (mida_byte[sizeof(_container) + _size])                                   \
+#define mida_bytemap(_container, _sizeof)                                     \
+    (mida_byte[sizeof(_container) + _sizeof])                                 \
     {                                                                         \
         0                                                                     \
     }
 
 /**
- * @def mida_bytemap(_size)
- * @brief Creates a bytemap buffer with local storage, with the given size
- *
- * C99 only. Creates a compound literal for a bytemap of the specified size.
- *
- * @param _size Size of the data that will be stored with metadata
- * @return A compound literal initialized to zero
- */
-#define mida_bytemap(_size) mida_ext_bytemap(struct mida_metadata, _size)
-
-/**
- * @def mida_ext_array(_container, _type, ...)
+ * @def mida_array(_container, _type, ...)
  * @brief Creates an array with extended MIDA metadata
  *
- * C99 only. Creates an array of the specified type with values provided
- * as a compound literal, and wraps it with extended MIDA metadata.
+ * C99 only. Creates an unnamed array of the specified type with values
+ * provided as a compound literal, and wraps it with extended MIDA metadata.
  *
  * @param _container The type of the container structure
  * @param _type The type of array elements
  * @param ... Compound literal array initialization values
  * @return Pointer to the array with extended MIDA metadata
  */
-#define mida_ext_array(_container, _type, ...)                                \
-    (_type *)(__mida_wrap(                                                    \
+#define mida_array(_container, _type, ...)                                    \
+    (_type *)(__mida_nwrap(                                                   \
         sizeof(_container), (_type[])__VA_ARGS__,                             \
         sizeof((_type[])__VA_ARGS__),                                         \
-        sizeof((_type[])__VA_ARGS__) / sizeof(_type),                         \
-        mida_ext_bytemap(_container, sizeof((_type[])__VA_ARGS__))))
+        mida_bytemap(_container, sizeof((_type[])__VA_ARGS__))))
 
 /**
- * @def mida_array(_type, ...)
- * @brief Creates an array with MIDA metadata
- *
- * C99 only. Creates an array of the specified type with values provided
- * as a compound literal, and wraps it with MIDA metadata.
- *
- * @param _type The type of array elements
- * @param ... Compound literal array initialization values
- * @return Pointer to the array with MIDA metadata
- */
-#define mida_array(_type, ...)                                                \
-    mida_ext_array(struct mida_metadata, _type, __VA_ARGS__)
-
-/**
- * @def mida_ext_struct(_container, _type, ...)
- * @brief Creates a structure with extended MIDA metadata
+ * @def mida_struct(_container, _type, ...)
+ * @brief Creates an unnamed structure with extended MIDA metadata
  *
  * C99 only. Creates a structure of the specified type with values provided
  * as a compound literal, and wraps it with extended MIDA metadata.
@@ -376,90 +198,31 @@ MIDA_API void *__mida_wrap(const size_t container_size,
  * @param ... Compound literal structure initialization values
  * @return Pointer to the structure with extended MIDA metadata
  */
-#define mida_ext_struct(_container, _type, ...)                               \
-    mida_ext_array(_container, _type, { __VA_ARGS__ })
+#define mida_struct(_container, _type, ...)                                   \
+    mida_array(_container, _type, { __VA_ARGS__ })
 
 /**
- * @def mida_struct(_type, ...)
- * @brief Creates a structure with MIDA metadata
+ * @def mida_string(_container, _string)
+ * @brief Creates a string literal with extended MIDA metadata
  *
- * C99 only. Creates a structure of the specified type with values provided
- * as a compound literal, and wraps it with MIDA metadata.
- *
- * @param _type The structure type
- * @param ... Compound literal structure initialization values
- * @return Pointer to the structure with MIDA metadata
- */
-#define mida_struct(_type, ...) mida_array(_type, { __VA_ARGS__ })
-
-#endif /* MIDA_SUPPORTS_C99 */
-
-/**
- * @def mida_ext_container(_container, _base)
- * @brief Retrieves the extended MIDA container structure for a given data
- * pointer
- *
- * Given a pointer to data managed by MIDA, returns a pointer to the
- * extended container structure that holds its metadata.
+ * C99 only. Creates a string with the provided string literal and wraps it
+ * with extended MIDA metadata.
  *
  * @param _container The type of the container structure
- * @param _base Pointer to data managed by MIDA
- * @return Pointer to the extended container structure containing the metadata
+ * @param _string The string literal to be wrapped
+ * @return Pointer to the string with extended MIDA metadata
+ *
+ * @note The returned string can be used with standard string functions
+ * while still maintaining access to its metadata.
  */
-#define mida_ext_container(_container, _base)                                 \
+#define mida_string(_container, _string)                                      \
+    (char *)(mida_wrap(_container, _string,                                   \
+                       mida_bytemap(_container, sizeof(_string))))
+
+#endif /* MIDA_WITH_C99 */
+
+#define MIDA(_container, _base)                                               \
     ((_container *)((mida_byte *)(_base) - sizeof(_container)))
-
-/**
- * @def mida_container(_base)
- * @brief Retrieves the MIDA container structure for a given data pointer
- *
- * Given a pointer to data managed by MIDA, returns a pointer to the
- * container structure that holds its metadata.
- *
- * @param _base Pointer to data managed by MIDA
- * @return Pointer to the mida structure containing the metadata
- */
-#define mida_container(_base) mida_ext_container(struct mida_metadata, _base)
-
-/**
- * @def mida_ext_sizeof(_container, _base)
- * @brief Gets the total size of data managed by MIDA
- *
- * @param _container The type of the container structure
- * @param _base Pointer to data managed by MIDA
- * @return The total size of the data in bytes
- */
-#define mida_ext_sizeof(_container, _base)                                    \
-    mida_ext_container(_container, _base)->size
-
-/**
- * @def mida_sizeof(_base)
- * @brief Gets the total size of data managed by MIDA
- *
- * @param _base Pointer to data managed by MIDA
- * @return The total size of the data in bytes
- */
-#define mida_sizeof(_base) mida_ext_sizeof(struct mida_metadata, _base)
-
-/**
- * @def mida_ext_length(_container, _base)
- * @brief Gets the number of elements in an array managed by MIDA
- *
- * @param _container The type of the container structure
- * @param _base Pointer to data managed by MIDA
- * @return The number of elements in the array
- */
-#define mida_ext_length(_container, _base)                                    \
-    mida_ext_container(_container, _base)->length
-
-/**
- * @def mida_length(_base)
- * @brief Gets the number of elements in an array managed by MIDA
- *
- * @param _base Pointer to data managed by MIDA
- * @return The number of elements in the array
- */
-#define mida_length(_base) mida_ext_length(struct mida_metadata, _base)
 
 #ifndef MIDA_HEADER
 
@@ -469,7 +232,7 @@ MIDA_API void *__mida_wrap(const size_t container_size,
 #define __mida_data_from_container(_container_ptr, _container_size)           \
     ((mida_byte *)_container_ptr + _container_size)
 #define __mida_container_from_data(_data_ptr, _container_size)                \
-    ((mida_byte *)_data_ptr - _container_size)
+    (void *)((mida_byte *)_data_ptr - _container_size)
 
 MIDA_API void *
 __mida_malloc(const size_t container_size,
@@ -479,11 +242,8 @@ __mida_malloc(const size_t container_size,
     const size_t data_size = element_size * count,
                  total_size = container_size + data_size;
     mida_byte *container = malloc(total_size);
-    struct mida_metadata *mida = (struct mida_metadata *)container;
-    if (!container) return NULL;
-    mida->size = data_size;
-    mida->length = count;
-    return __mida_data_from_container(container, container_size);
+    return !container ? NULL
+                      : __mida_data_from_container(container, container_size);
 }
 
 MIDA_API void *
@@ -494,11 +254,8 @@ __mida_calloc(const size_t container_size,
     const size_t data_size = element_size * count,
                  total_size = container_size + data_size;
     mida_byte *container = calloc(1, total_size);
-    struct mida_metadata *mida = (struct mida_metadata *)container;
-    if (!container) return NULL;
-    mida->size = data_size;
-    mida->length = count;
-    return __mida_data_from_container(container, container_size);
+    return !container ? NULL
+                      : __mida_data_from_container(container, container_size);
 }
 
 MIDA_API void *
@@ -513,32 +270,19 @@ __mida_realloc(const size_t container_size,
         mida_byte *original_container =
             __mida_container_from_data(base, container_size);
         mida_byte *container = realloc(original_container, total_size);
-        struct mida_metadata *mida = (struct mida_metadata *)container;
-        if (!container) return NULL;
-        mida->size = data_size;
-        mida->length = count;
-        return __mida_data_from_container(container, container_size);
+        return !container
+                   ? NULL
+                   : __mida_data_from_container(container, container_size);
     }
     return __mida_malloc(container_size, element_size, count);
 }
 
-MIDA_API void
-__mida_free(const size_t container_size, void *base)
-{
-    mida_byte *container = __mida_container_from_data(base, container_size);
-    free(container);
-}
-
 MIDA_API void *
-__mida_wrap(const size_t container_size,
-            void *data,
-            const size_t size,
-            const size_t length,
-            mida_byte *const container)
+__mida_nwrap(const size_t container_size,
+             void *data,
+             const size_t size,
+             mida_byte *const container)
 {
-    struct mida_metadata *mida = (struct mida_metadata *)container;
-    mida->size = size;
-    mida->length = length;
     return memcpy(__mida_data_from_container(container, container_size), data,
                   size);
 }


### PR DESCRIPTION
Rewrite to emphasize "metadata injection" aspect, which is the core functionality being promoted for this library. And not being able to access 'size' and 'length'

This pull request introduces a set of changes to enhance the `mida` library by simplifying its API, improving metadata handling, and adding comprehensive examples to demonstrate its usage. The most significant changes include updates to the `mida.h` API, the addition of example programs, and a new `Makefile` for building these examples.

### API Simplifications and Improvements
* Replaced the `mida_ext_*` macros with unified `mida_*` macros (`mida_malloc`, `mida_calloc`, `mida_realloc`) for a cleaner and more intuitive API. Deprecated redundant standard metadata macros. [[1]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL113-R72) [[2]](diffhunk://#diff-9eef622f4f5e5f86123200f934ff90579785f0dee0b82def409163d2d1760fdcL159-R90)
* Consolidated the `MIDA_BYTEMAP` macro to handle metadata and data allocation in a single definition, replacing the old `MIDA_EXT_BYTEMAP` macro.
* Updated C99 support macro from `MIDA_SUPPORTS_C99` to `MIDA_WITH_C99` for consistency.

### Example Programs
* Added five example programs (`array_length.c`, `complex_metadata.c`, `file_metadata.c`, `nested_metadata.c`, `timestamp.c`) demonstrating various use cases of the `mida` library, such as metadata for arrays, complex structures, and nested objects. [[1]](diffhunk://#diff-e1511c5e4467c791a4be08b12d411c718f64d484f3517ef0e1723fede23dd155R1-R36) [[2]](diffhunk://#diff-9ed8d8369c2cbe75eba0d8a0dbd5ee1a7067a106dabf444095dbd68d9f2193f4R1-R87) [[3]](diffhunk://#diff-74d69ebb5211d9f73ce544d9e92cc3cf20a92e85da148e393203b4a706581a5cR1-R54) [[4]](diffhunk://#diff-decfc1064e58be94e668b94e7db70d2a75c6b4008346d7fd3cb79ada689f6ab8R1-R107) [[5]](diffhunk://#diff-cc76ff435f45c7013f1a658a36b547126626325cefd7d83cc75397ddcc525bc9R1-R59)

### Build System
* Introduced a new `Makefile` in the `examples` directory to compile the example programs, with targets for building (`all`) and cleaning (`clean`).

### Miscellaneous
* Updated the `.gitignore` file to exclude all files except the necessary source files, `Makefile`, and `.gitignore` itself.