### PR TITLE
Exemplify mida_bytemap() usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ for (size_t i = 0; i < MIDA(ArrayMD, numbers)->length; i++) {
 printf("Array length: %zu\n", MIDA(ArrayMD, numbers)->length);  // 5
 ```
 
+Or if you want to use C99 compound literals, you can skip the `MIDA_BYTEMAP` macro, and
+use `mida_bytemap` directly in the `mida_wrap` function:
+
+```c
+... // Previous code
+
+int data[5] = {0};
+int *numbers = mida_wrap(ArrayMD, data, mida_bytemap(ArrayMD, sizeof(data)));
+
+... // Continue with the rest of the code
+```
+
 ### Injecting Custom Metadata
 
 ```c

--- a/examples/file_metadata.c
+++ b/examples/file_metadata.c
@@ -16,15 +16,13 @@ int
 main()
 {
     // Create a buffer with file metadata
-    const char *content = "This is some example file content.\n"
-                          "It has multiple lines of text.\n"
-                          "It could represent a document or any other file.";
-
-    // Create a bytemap for our metadata and data
-    MIDA_BYTEMAP(FileMD, bytemap, strlen(content) + 1);
+    char content[] = "This is some example file content.\n"
+                     "It has multiple lines of text.\n"
+                     "It could represent a document or any other file.";
 
     // Wrap the data with metadata
-    char *file_data = mida_wrap(FileMD, (void *)content, bytemap);
+    char *file_data =
+        mida_wrap(FileMD, content, mida_bytemap(FileMD, sizeof(content)));
 
     // Set the metadata
     FileMD *meta = MIDA(FileMD, file_data);

--- a/test/test.c
+++ b/test/test.c
@@ -123,24 +123,19 @@ test_init_bytemap(void)
     };
 
     int zx[] = { 1, 2, 3 };
-    MIDA_BYTEMAP(MD, bytemap_zx, sizeof(zx));
     float zy[] = { 1.0f, 2.0f };
-    MIDA_BYTEMAP(MD, bytemap_zy, sizeof(zy));
     struct test z = {
-        test_wrap(zx, bytemap_zx),
-        test_wrap(zy, bytemap_zy),
+        test_wrap(zx, mida_bytemap(MD, sizeof(zx))),
+        test_wrap(zy, mida_bytemap(MD, sizeof(zy))),
         NULL,
     };
-    MIDA_BYTEMAP(MD, bytemap_z, sizeof(z));
 
     int x[] = { 1, 2, 3 };
-    MIDA_BYTEMAP(MD, bytemap_x, sizeof(x));
     float y[] = { 1.0f, 2.0f, 3.0f, 4.0f };
-    MIDA_BYTEMAP(MD, bytemap_y, sizeof(y));
     struct test foo = {
-        test_wrap(x, bytemap_x),
-        test_wrap(y, bytemap_y),
-        test_wrap(&z, bytemap_z),
+        test_wrap(x, mida_bytemap(MD, sizeof(x))),
+        test_wrap(x, mida_bytemap(MD, sizeof(y))),
+        test_wrap(&z, mida_bytemap(MD, sizeof(z))),
     };
 
     ASSERT_EQ(3, MIDA(MD, foo.x)->length);
@@ -349,14 +344,13 @@ test_shallow_mida_deep_nesting(void)
     struct {
         void **mixed_array;
     } container = {
-        .mixed_array =
-            test_array(void *,
-                       {
-                           (void *)regular_strings, // Regular array of strings
-                           (void *)regular_2d_array, // Regular 2D array
-                           (void *)(const char *[]){ "foo", "bar",
-                                                     "baz" } // Unnamed array
-                       })
+        .mixed_array = test_array(
+            void *,
+            {
+                regular_strings, // Regular array of strings
+                regular_2d_array, // Regular 2D array
+                (const char *[]){ "foo", "bar", "baz" } // Unnamed array
+            })
     };
 
     // Test that the outermost array has metadata


### PR DESCRIPTION
This pull request introduces changes to simplify the usage of the `mida_bytemap` function and improve code readability by removing the `MIDA_BYTEMAP` macro in favor of direct calls to `mida_bytemap`. Additionally, it includes minor refactoring for clarity in test cases and examples.

### Simplification of `mida_bytemap` usage:
* Updated the documentation in `README.md` to demonstrate the use of `mida_bytemap` directly in the `mida_wrap` function, eliminating the need for the `MIDA_BYTEMAP` macro.
* Replaced the `MIDA_BYTEMAP` macro with direct calls to `mida_bytemap` in `examples/file_metadata.c` when wrapping metadata and data.

### Refactoring of test cases:
* Simplified test cases in `test/test.c` by removing `MIDA_BYTEMAP` and using `mida_bytemap` directly in `test_init_bytemap`. This change reduces redundancy and improves code clarity.
* Refactored the `test_shallow_mida_deep_nesting` test in `test/test.c` to improve readability by reformatting the initialization of the `mixed_array` field.